### PR TITLE
Use AJAX for file loading on device

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -208,8 +208,7 @@
     <script src="phonegap.js"></script>
     <script src="bundle.js"></script>
     <script>
-        // Allow launching in desktop browser as well as phonegap shell
-        var loadEvent = (window.device ? 'deviceready' : 'DOMContentLoaded');
+        var loadEvent = (window.cordova ? 'deviceready' : 'DOMContentLoaded');
         document.addEventListener(loadEvent, function() {
             require('app').init({
               mockLocationSelector: '#enable-mock-location'

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4,8 +4,6 @@ var $ = require('jquery');
 
 module.exports = {
     init: function (options) {
-        require('./fileReader').init();
-
         require('./ui').init();
         require('./cards').init();
         require('./map').init({

--- a/src/js/fileReader.js
+++ b/src/js/fileReader.js
@@ -1,44 +1,13 @@
 'use strict';
 
-// Read files.
-// When running on device, fetch from local filesystem.
-// When running in browser (during development), fetch via Ajax.
-
+// Fetch files via ajax
 var $ = require('jquery');
 
-var _fileSystemRoot;
-
 module.exports = {
-    init: init,
     readAsText: readAsText
 };
 
-function init() {
-    if (window.device) {
-        window.requestFileSystem(LocalFileSystem.PERSISTENT, 0, function (fileSystem) {
-            _fileSystemRoot = fileSystem.root;
-        }, fail);
-    }
-}
-
 function readAsText(filePath, onFail, onSuccess) {
-    var read = (window.device ? readLocalFile : readRelativeUrl);
-    read(filePath, onFail, onSuccess);
-}
-
-function readLocalFile(filePath, onFail, onSuccess) {
-    _fileSystemRoot.getFile(filePath, null, function (fileEntry) {
-        fileEntry.file(function (file) {
-            var reader = new FileReader();
-            reader.onloadend = function(evt) {
-                onSuccess(evt.target.result);
-            };
-            reader.readAsText(file);
-        }, onFail);
-    }, onFail);
-}
-
-function readRelativeUrl(filePath, onFail, onSuccess) {
     $.ajax({
         url: filePath,
         success: onSuccess,


### PR DESCRIPTION
window.cordova appears to be a good indicator that a phonegap app
is running on a device, not in the browser. Device apps are able
to request files in the app root via ajax, similarly to browser.
The FileReader api seems to only have access to the "Documents"
directory.

I chose to keep the file reader abstraction even though all
platforms will use the same mechanism as it might be useful
to generate all requests from a single module.

Fixes #15
