### PR TITLE
Change zone style on map based on quest status

### DIFF
--- a/src/js/cards.js
+++ b/src/js/cards.js
@@ -10,6 +10,7 @@ var $ = require('jquery'),
     zoneContentTemplate = require('../templates/zone-content.ejs');
 
 var deckFinishedBus = new Bacon.Bus(),
+    topicStartedBus= new Bacon.Bus(),
     topicFinishedBus = new Bacon.Bus();
 
 function init() {
@@ -50,6 +51,7 @@ function openZoneDeck(zone, showHtml) {
                     $deck.attr('data-quest', quest);
 
                     setQuestCards($card, zone, quest);
+                    topicStartedBus.push(zone);
                 }
             });
         });
@@ -122,6 +124,7 @@ function navigateCards(e) {
 module.exports = {
     init: init,
     deckFinishedStream: deckFinishedBus.map(_.identity),
+    topicStartedStream: topicStartedBus.map(_.identity),
     topicFinishedStream: topicFinishedBus.map(_.identity),
     openQuestDeck: openQuestDeck,
     openZoneDeck: openZoneDeck,

--- a/src/js/questUtils.js
+++ b/src/js/questUtils.js
@@ -9,18 +9,20 @@ exports = module.exports = {
     STATUS_FINISHED: 3,
 
     noQuestsStarted: function(zone) {
-        // Returns true iff no quests have ever been started in this zone
-        return !_.contains(zone.status, exports.STATUS_STARTED) && !_.contains(zone.status, exports.STATUS_FINISHED);
+        // Returns true if no quests have ever been started in this zone
+        return !_.contains(zone.status, exports.STATUS_STARTED) &&
+               !_.contains(zone.status, exports.STATUS_FINISHED);
     },
 
     questInProgress: function(zone) {
-        // Returns true iff there is a quest in progress in this zone
+        // Returns true if there is a quest in progress in this zone
         return _.contains(zone.status, exports.STATUS_STARTED);
     },
 
     allQuestsDone: function(zone) {
-        // Returns true iff all quests are finished
-        return !_.contains(zone.status, exports.STATUS_STARTED) && !_.contains(zone.status, exports.STATUS_NOT_STARTED);
+        // Returns true if all quests are finished
+        return !_.contains(zone.status, exports.STATUS_STARTED) &&
+               !_.contains(zone.status, exports.STATUS_NOT_STARTED);
     },
 
     getCurrentQuest: function(zone) {

--- a/src/js/zoneStyles.js
+++ b/src/js/zoneStyles.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+    inactive   : { fillOpacity: 0.4, weight: 2, color: '#1b1bb3'},
+    active     : { fillOpacity: 0.4, weight: 2, color: '#1bb31b'},
+
+    unstarted  : { fillColor: '#ff0000' },
+    inProgress : { fillColor: '#ff00ff' },
+    done       : { fillColor: '#000000' }
+};
+


### PR DESCRIPTION
Zones can be in 3 states, based on the status of their quests:  Unstarted, InProgress and Done.  Allows changing the color when a zone enters a new state.
