### PR TITLE
Implement click to view deck for completed quests.

### DIFF
--- a/src/js/cards.js
+++ b/src/js/cards.js
@@ -30,7 +30,7 @@ function openQuestDeck(zone, quest) {
         .onValue(addDeckToPage);
 }
 
-function openZoneDeck(zone, showHtml) {
+function openZoneDeck(zone, showHtml, trackProgress) {
     var directory = path.join('zones', zone.id);
     var htmlPath = path.join(directory, 'index.html');
 
@@ -54,13 +54,15 @@ function openZoneDeck(zone, showHtml) {
                     });
 
             htmlStream.onValue(addDeckToPage);
-            topicStartedBus.push(zone);
+            if (trackProgress) {
+                topicStartedBus.push(zone);
+            }
         }
     });
 
     // Load all quest content and apply the cards to the deck
     _.each(zone.quests, function(quest) {
-        zone.status[quest] = questUtils.STATUS_STARTED;
+        zone.status[quest] = trackProgress ? questUtils.STATUS_STARTED : questUtils.STATUS_FINISHED;
         questContentBus.push(quest);
     });
 }

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -27,6 +27,8 @@ module.exports = {
         Bacon.mergeAll(questManager.zoneStatusChangeStream,
                 Bacon.fromArray(questManager.zones))
             .onValue(changeZoneStyle);
+
+        initZoneClickEvents(questManager);
     }
 };
 
@@ -65,6 +67,7 @@ function initQuestZoneLayers(map, zones) {
 
         zone.latLng = latLng;
         zone.layer = circle;
+        zone.clickStream = Bacon.fromEventTarget(circle, 'click').map(zone);
     });
 }
 
@@ -85,4 +88,10 @@ function changeZoneStyle(zone) {
     } else if (questUtils.questInProgress(zone)) {
         zone.layer.setStyle(zoneStyle.inProgress);
     }
+}
+
+function initZoneClickEvents(questManager) {
+    _.each(questManager.zones, function(zone) {
+        zone.clickStream.filter(questUtils.allQuestsDone).onValue(questManager.showDeck);
+    });
 }

--- a/src/js/questManager.js
+++ b/src/js/questManager.js
@@ -33,7 +33,8 @@ module.exports = {
         return {
             zones: zones,
             zoneDiffProperty: zoneDiffProperty,
-            zoneStatusChangeStream: Bacon.mergeAll(finishedStream, cards.topicStartedStream)
+            zoneStatusChangeStream: Bacon.mergeAll(finishedStream, cards.topicStartedStream),
+            showDeck: showDeck
         };
     }
 };
@@ -111,11 +112,15 @@ function closeDialogAndSwitchToZone(zone) {
 }
 
 function switchToZone(zone) {
-    cards.openZoneDeck(zone, true);
+    cards.openZoneDeck(zone, true, true);
 }
 
 function cleanupZoneChange(diff) {
     if (diff.oldZone) {
         diff.oldZone.invitationDialog.close();
     }
+}
+
+function showDeck(zone) {
+    cards.openZoneDeck(zone, true, false);
 }


### PR DESCRIPTION
This change allows a user to click/tap on a completed zone to launch that zone's quest decks. Previously, a user would have to physically reenter the zone to launch the decks.
