### PR TITLE
Hide zone locations. Add zone location hint.

### DIFF
--- a/src/js/zoneStyles.js
+++ b/src/js/zoneStyles.js
@@ -1,10 +1,11 @@
 "use strict";
 
 module.exports = {
+    initial    : { fillOpacity: 0.0, weight: 2, opacity: 0.5 },
     inactive   : { fillOpacity: 0.25, weight: 2, opacity: 0.5 },
     active     : { fillOpacity: 0.5, opacity: 1, weight: 2 },
 
-    unstarted  : { fillColor: '#565656', color: '#565656', dashArray: '5, 5' },
+    unstarted  : { fillColor: '#565656', color: '', dashArray: '5, 5' },
     inProgress : { fillColor: '#00c6ff', color: '#00c6ff', dashArray: '0, 0' },
     done       : { fillColor: '#00ed1c', color: '#00ed1c', dashArray: '0, 0'  }
 };


### PR DESCRIPTION
- Zones are now not shown on the map, but users are given a hint as to
  their location. The marker for the hint starts as a circle with
  no radius, then grows over 1 second to the full size of the zone.
  The color of the marker also becomes more and more yellow. When the
  animation completes, the marker disappears again, and the animation
  is triggered 30 seconds later. The timing between each hint cycle,
  as well as the duration of the hint, can be configured.
- Remove the stroke for the unstarted marker to better match the hint
  style.
