### PR TITLE
Center map on current location

### DIFF
--- a/src/js/map.js
+++ b/src/js/map.js
@@ -20,6 +20,7 @@ module.exports = {
 
         latLngStream
             .doAction(updateGhostTrail, ghostMarkers, map)
+            .doAction(centerMapOnPosiiton, map)
             .onValue(locationMarker, 'setLatLng');
 
         initQuestZoneLayers(map, questManager.zones);
@@ -99,6 +100,10 @@ function addLocationMarkerToMap(map) {
             .addTo(map);
 
     return marker;
+}
+
+function centerMapOnPosiiton(map, latlng) {
+    map.panTo(latlng);
 }
 
 function initQuestZoneLayers(map, zones) {


### PR DESCRIPTION
As the user moves, instead of the map being fixed on a point, the map
updates around the user in a style more consistent with driving
directors or google maps.  This was a client request.

Fixes #31
