### PR TITLE
Make the menu button easier to click

### DIFF
--- a/src/sass/partials/_panel.scss
+++ b/src/sass/partials/_panel.scss
@@ -8,9 +8,11 @@
     cursor: pointer;
     opacity: 0.75;
     transition: $transition;
+    height: 55px;
+    width: 55px;
 
     i {
-        font-size: 3rem;
+        font-size: 3.3rem;
     }
 
     @media screen and #{$screen-xs}, #{$screen-sm}, #{$screen-md} {
@@ -36,7 +38,7 @@
         }
 
         i {
-            font-size: 2.4rem;
+            font-size: 2.8rem;
             line-height: 3.2rem;
         }
     }


### PR DESCRIPTION
Make the menu button easier to click.
Expand the size of the menu button container
element as well as the size of the menu button
itself to make it easier to click.

Refs #36
