### PR TITLE
Remove zone marker animation

### DIFF
--- a/src/js/zoneStyles.js
+++ b/src/js/zoneStyles.js
@@ -1,12 +1,25 @@
 "use strict";
 
 module.exports = {
-    initial    : { fillOpacity: 0.0, weight: 2, opacity: 0.5 },
-    inactive   : { fillOpacity: 0.25, weight: 2, opacity: 0.5 },
-    active     : { fillOpacity: 0.5, opacity: 1, weight: 2 },
-
-    unstarted  : { fillColor: '#565656', color: '', dashArray: '5, 5' },
-    inProgress : { fillColor: '#00c6ff', color: '#00c6ff', dashArray: '0, 0' },
-    done       : { fillColor: '#00ed1c', color: '#00ed1c', dashArray: '0, 0'  }
+    inactive: {
+        fillOpacity: 0.25,
+        weight: 2,
+        opacity: 0.5
+    },
+    active: {
+        fillOpacity: 0.5,
+        weight: 2,
+        opacity: 1
+    },
+    unstarted: {
+        fillColor: '#ED349D',
+        color: '#ED349D',
+        dashArray: '5, 5',
+    },
+    done: {
+        fillColor: '#00ED1C',
+        color: '#00ED1C',
+        dashArray: '0, 0',
+    }
 };
 


### PR DESCRIPTION
The animation were designed for when the zone markers
were larger and there were fewer of them. Also, @mmcfarland
noted that the animations were annoying during field
testing and lead to a bad experience.
- Remove zone animation code.
- Simplify zone style structure and application of styles.
- Removed unneeded styles.

Connects to #50
