### PR TITLE
Close menu if selected page is already active.

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -71,6 +71,8 @@ function togglePages(e) {
         pageManager.crossFade($('#' + activePage), $('#' + target));
         snap.close();
         pageManager.loadPage(target, $('#' + target), questManager);
+    } else {
+        toggleMenu();
     }
 }
 


### PR DESCRIPTION
- If the selected menu item is for the active page, close the
  menu. Previously, the menu would stay open.

Refs #39 

**To test:**
- Start the app and navigate to the map.
- Open the menu.
- Select "Explore the Map". The menu should close.
- Try this with all of the other pages when they are active.

Connects to #39
