### PR TITLE
Enable zone confirmation dialog

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -58,7 +58,7 @@
             </div>
             <div id="confirmation" class="quest-confirmation clearfix">
                 <div class="quest-confirmation-text">You are approaching the <b id="confirmation-quest-name">Old Mill House &amp; Forebay</b> quest.</div>
-                <div class="btn btn-primary pull-right">Explore</div>
+                <div class="btn btn-primary pull-right" id="explore-zone">Explore</div>
             </div>
         </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -43,7 +43,6 @@
                     <div class="modaloverlay-content">
                         <h1>A look through the past</h1>
                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsum eligendi harum beatae autem velit corporis, dolor consequuntur est, saepe sit dolorem nemo animi sequi quas non inventore pariatur. Quasi, magnam!</p>
-                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Itaque corporis ut doloremque facilis, vero sequi assumenda molestiae, aut animi eius quidem cumque. Facilis ex rerum, consequuntur. Recusandae odio reprehenderit atque?</p>
                         <div id="button-close-introduction" class="modaloverlay-button">Get Started</div>
                     </div>
                 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,12 @@
             <a href="#menu" class="menu-link"><i class="icon-menu"></i></a>
             <div id="card-holder">
             </div>
+            <div id="confirmation" class="quest-confirmation clearfix">
+                <div class="quest-confirmation-text">You are approaching the <b id="confirmation-quest-name">Old Mill House &amp; Forebay</b> quest.</div>
+                <div class="btn btn-primary pull-right">Explore</div>
+            </div>
         </div>
+
         <div id="quests" class="page page-static">
             <div class="page-static-container">
                 <div class="page-header">

--- a/src/js/questManager.js
+++ b/src/js/questManager.js
@@ -23,8 +23,9 @@ module.exports = {
                 .doAction(onZoneFinished);
 
         zoneChangeStream
+            .doAction(hideZoneActivationDialog)
             .filter(_.isObject)
-            .onValue(switchToZone);
+            .onValue(confirmZoneActivation);
 
         initStatus();
 
@@ -91,4 +92,24 @@ function switchToZone(zone) {
 
 function showDeck(zone) {
     cards.openZoneDeck(zone, ACTIVE_QUEST);
+}
+
+function confirmZoneActivation(zone) {
+    var $confirmation = $('#confirmation');
+
+    $confirmation.find('#confirmation-quest-name').html(zone.title);
+    $confirmation.addClass('active');
+
+    $('#explore-zone').bind('click', function() {
+        cards.openZoneDeck(zone, ACTIVE_QUEST);
+        hideZoneActivationDialog();
+    });
+}
+
+function hideZoneActivationDialog() {
+    var $confirmation = $('#confirmation'),
+        $exploreZone = $confirmation.find('#explore-zone');
+
+    $confirmation.removeClass('active');
+    $exploreZone.unbind();
 }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -4,6 +4,7 @@
 @import "modules/scrollable";
 @import "modules/cards";
 @import "modules/intro";
+@import "modules/confirmation";
 
 // Partials
 @import "partials/mixins";

--- a/src/sass/modules/_cards.scss
+++ b/src/sass/modules/_cards.scss
@@ -5,6 +5,7 @@
         bottom: 0;
         left: 0;
         right: 0;
+        background: #000;
         box-shadow: 0 0 15px rgba(0,0,0,0.75);
 
         .card {

--- a/src/sass/modules/_cards.scss
+++ b/src/sass/modules/_cards.scss
@@ -254,3 +254,8 @@
         transform: translate3d(-125%,0,0);
     }
 }
+
+#card-holder {
+    z-index: 1000;
+    position: relative;
+}

--- a/src/sass/modules/_confirmation.scss
+++ b/src/sass/modules/_confirmation.scss
@@ -1,0 +1,21 @@
+.quest-confirmation {
+  position: fixed;
+  display: table;
+  bottom: 0;
+  width: 100%;
+  background-color: #fff;
+  padding: 1rem;
+  transition: $transition;
+  transform: translate(0, 100%);
+  z-index: 200;
+  opacity: .5;
+  &.active {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
+}
+
+.quest-confirmation-text {
+  display: table-cell;
+  vertical-align: middle;
+}

--- a/src/sass/partials/_panel.scss
+++ b/src/sass/partials/_panel.scss
@@ -11,8 +11,17 @@
     height: 55px;
     width: 55px;
 
+    .page-map & {
+        i {
+            background-color: #060623;
+        }
+    }
+
     i {
         font-size: 3.3rem;
+        border-radius: 4px;
+        transition: $transition;
+
     }
 
     @media screen and #{$screen-xs}, #{$screen-sm}, #{$screen-md} {
@@ -20,7 +29,7 @@
         left: 8px;
     }
 
-    &:hover {
+    &:hover, &:active {
         color: white;
         opacity: 1;
         text-decoration: none;


### PR DESCRIPTION
When the user enters a zone, open a dialog that asks if they
would like to "explore" the zone (i.e. open the slideshow).

* Open confirmation dialog when user enters zone.
* Don't show confirmation dialog when tapping on a zone
that has previously been entered.
* Dismiss confirmation dialog when exiting zone.

**To test:**

- Enable mock locations.
- Navigate to a zone. The confirmation dialog should appear.
- Click explore. This should launch the zone slideshow.
- Navigate to another zone.
- Instead of clicking explore on the confirmation dialog, leave the zone. The dialog should disappear.
- Turn off mock locations.
- Click on the first zone. The slideshow appear without the confirmation dialog.

Connects #92

Includes commits from #91 

