### PR TITLE
Adding plist generation script.

### DIFF
--- a/scripts/create-plist.sh
+++ b/scripts/create-plist.sh
@@ -1,0 +1,48 @@
+echo "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+   <key>items</key>
+   <array>
+       <dict>
+           <key>assets</key>
+           <array>
+               <dict>
+                   <key>kind</key>
+                   <string>software-package</string>
+                   <key>url</key>
+                   <string>$JENKINS_BUILD_URL/app-$BUILD_NUMBER.ipa</string>
+               </dict>
+               <dict>
+                   <key>kind</key>
+                   <string>display-image</string>
+                   <key>needs-shine</key>
+                   <true/>
+                   <key>url</key>
+                   <string>$SMALL_ICON_URL</string>
+               </dict>
+               <dict>
+                   <key>kind</key>
+                   <string>full-size-image</string>
+                   <key>needs-shine</key>
+                   <true/>
+                   <key>url</key>
+                   <string>$LARGE_ICON_URL</string>
+               </dict>
+           </array>
+           <key>metadata</key>
+           <dict>
+               <key>bundle-identifier</key>
+               <string>$BUNDLE_IDENTIFIER</string>
+               <key>bundle-version</key>
+               <string>$VERSION</string>
+               <key>kind</key>
+               <string>software</string>
+               <key>title</key>
+               <string>Water Revealed</string>
+               <key>subtitle</key>
+               <string>Water Revealed</string>
+           </dict>
+       </dict>
+   </array>
+</dict>
+</plist>"


### PR DESCRIPTION
In order to do over the air downloads for iOS development we need to create a
special plist file that references the ipa. Added a shell script that generates
the appropriate file based on environment variables set by Jenkins.

Connects #100 

To test:

 * choose a device that is provisioned to work with the application.
 * Browse to Jenkins and find the latest build.
 * Click the install link.