### PR TITLE
Add quest progress indicator

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -53,6 +53,7 @@
 
         <div id="map" class="page page-map active">
             <div id="tour-map" style="width:100%;height:100%;"></div>
+            <div id="progress" class="ui-link" data-page="quests"></div>
             <a href="#menu" class="menu-link"><i class="icon-menu"></i></a>
             <div id="card-holder">
             </div>

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var $        = require('jquery'),
+var $ = require('jquery'),
+    _ = require('lodash'),
     jqToggle = require('toggles'),
-    Snap     = require('Snap'),
+    Snap = require('Snap'),
     pageManager = require('./pages');
 
 var snap,

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -4,7 +4,9 @@ var $ = require('jquery'),
     _ = require('lodash'),
     jqToggle = require('toggles'),
     Snap = require('Snap'),
-    pageManager = require('./pages');
+    pageManager = require('./pages'),
+    progressTemplate = require('../templates/progress.ejs'),
+    zoneUtils = require('./zoneUtils');
 
 var snap,
     questManager;
@@ -21,6 +23,7 @@ function init(options) {
 
     initSnap();
     initToggleButtons();
+    initQuestProgress(questManager);
 
     $('.menu-link').on('click', toggleMenu);
     $('.menu').on('click', 'a', togglePages);
@@ -52,6 +55,36 @@ function initSnap() {
         slideIntent: 40,
         minDragDistance: 5
     });
+}
+
+function initQuestProgress(questManager) {
+    var selector = '#progress';
+
+    $(selector).on('click', togglePages);
+
+    questManager.zoneStatusChangeStream
+        .toProperty(0)
+        .map(updateProgress, questManager)
+        .onValue(renderProgress, selector);
+}
+
+function updateProgress(questManager) {
+    var count = _.reduce(questManager.zones, function(result, zone) {
+        if (zone.status === zoneUtils.STATUS_FINISHED) {
+            return result + 1;
+        }
+
+        return result;
+    }, 0);
+
+    return {
+        total: questManager.zones.length,
+        count: count
+    };
+}
+
+function renderProgress(selector, context) {
+    $(selector).html(progressTemplate(context));
 }
 
 function toggleMenu() {

--- a/src/js/zoneUtils.js
+++ b/src/js/zoneUtils.js
@@ -1,8 +1,8 @@
 'use strict';
 
 exports = module.exports = {
-    STATUS_NOT_STARTED: 1,
-    STATUS_FINISHED: 2,
+    STATUS_NOT_STARTED: 0,
+    STATUS_FINISHED: 1,
 
     zoneFinished: function(zone) {
         return zone && zone.status === exports.STATUS_FINISHED;

--- a/src/sass/modules/_cards.scss
+++ b/src/sass/modules/_cards.scss
@@ -5,6 +5,7 @@
         bottom: 0;
         left: 0;
         right: 0;
+        background: #000;
         box-shadow: 0 0 15px rgba(0,0,0,0.75);
 
         .card {

--- a/src/sass/partials/_panel.scss
+++ b/src/sass/partials/_panel.scss
@@ -136,3 +136,18 @@
         }
     }
 }
+
+#progress {
+    background-color: coral;
+    border-radius: 10px;
+    color: #fff;
+    cursor: pointer;
+    font-weight: 600;
+    position: absolute;
+    right: 10px;
+    top: 10px;
+
+    span {
+      padding: 5px 10px;
+    }
+}

--- a/src/templates/progress.ejs
+++ b/src/templates/progress.ejs
@@ -1,0 +1,1 @@
+<span><%= count %> / <%= total %></span>


### PR DESCRIPTION
Add a small UI element that indicates how many zones in the
current quest are completed. If zones are hidden because
the extent of the map is cropping them out, this helps
the user see that there may be additional zones to visit.

* Update quest progress whenever a zone status is changed.
* Wire element to open quest details page on tap.
* Add basic CSS for element.

Note: the styling of the element is temporary.

**To Test:**
- Open the app. You should see the indicator showing `0/13`.
- Visit a zone. The indicator should update to `1/13`.
- Click the indicator. It should open the quest progress page.

Connects to #102 

