### PR TITLE
Add status bar cordova plugin and config.

### DIFF
--- a/plugins/android.json
+++ b/plugins/android.json
@@ -11,6 +11,10 @@
                         {
                             "xml": "<feature name=\"Compass\"><param name=\"android-package\" value=\"org.apache.cordova.deviceorientation.CompassListener\" /></feature>",
                             "count": 1
+                        },
+                        {
+                            "xml": "<feature name=\"StatusBar\"><param name=\"android-package\" value=\"org.apache.cordova.statusbar.StatusBar\" /><param name=\"onload\" value=\"true\" /></feature>",
+                            "count": 1
                         }
                     ]
                 }
@@ -36,6 +40,9 @@
             "PACKAGE_NAME": "com.azavea.pwd_waterworks_revealed"
         },
         "cordova-plugin-geolocation": {
+            "PACKAGE_NAME": "com.azavea.pwd_waterworks_revealed"
+        },
+        "cordova-plugin-statusbar": {
             "PACKAGE_NAME": "com.azavea.pwd_waterworks_revealed"
         }
     },

--- a/plugins/cordova-plugin-statusbar/CONTRIBUTING.md
+++ b/plugins/cordova-plugin-statusbar/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+-->
+
+# Contributing to Apache Cordova
+
+Anyone can contribute to Cordova. And we need your contributions.
+
+There are multiple ways to contribute: report bugs, improve the docs, and
+contribute code.
+
+For instructions on this, start with the 
+[contribution overview](http://cordova.apache.org/#contribute).
+
+The details are explained there, but the important items are:
+ - Sign and submit an Apache ICLA (Contributor License Agreement).
+ - Have a Jira issue open that corresponds to your contribution.
+ - Run the tests so your patch doesn't break existing functionality.
+
+We look forward to your contributions!

--- a/plugins/cordova-plugin-statusbar/LICENSE
+++ b/plugins/cordova-plugin-statusbar/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/cordova-plugin-statusbar/NOTICE
+++ b/plugins/cordova-plugin-statusbar/NOTICE
@@ -1,0 +1,5 @@
+Apache Cordova
+Copyright 2012 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/plugins/cordova-plugin-statusbar/README.md
+++ b/plugins/cordova-plugin-statusbar/README.md
@@ -1,0 +1,297 @@
+<!---
+# license: Licensed to the Apache Software Foundation (ASF) under one
+#         or more contributor license agreements.  See the NOTICE file
+#         distributed with this work for additional information
+#         regarding copyright ownership.  The ASF licenses this file
+#         to you under the Apache License, Version 2.0 (the
+#         "License"); you may not use this file except in compliance
+#         with the License.  You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#         Unless required by applicable law or agreed to in writing,
+#         software distributed under the License is distributed on an
+#         "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#         KIND, either express or implied.  See the License for the
+#         specific language governing permissions and limitations
+#         under the License.
+-->
+
+# cordova-plugin-statusbar
+
+[![Build Status](https://travis-ci.org/apache/cordova-plugin-statusbar.svg)](https://travis-ci.org/apache/cordova-plugin-statusbar)
+
+StatusBar
+======
+
+> The `StatusBar` object provides some functions to customize the iOS and Android StatusBar.
+
+
+## Installation
+
+    cordova plugin add cordova-plugin-statusbar
+
+Preferences
+-----------
+
+#### config.xml
+
+-  __StatusBarOverlaysWebView__ (boolean, defaults to true). On iOS 7, make the statusbar overlay or not overlay the WebView at startup.
+
+        <preference name="StatusBarOverlaysWebView" value="true" />
+
+- __StatusBarBackgroundColor__ (color hex string, defaults to #000000). On iOS 7 and Android 5, set the background color of the statusbar by a hex string (#RRGGBB) at startup.
+
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+
+- __StatusBarStyle__ (status bar style, defaults to lightcontent). On iOS 7, set the status bar style. Available options default, lightcontent, blacktranslucent, blackopaque.
+
+        <preference name="StatusBarStyle" value="lightcontent" />
+
+### Android Quirks
+The Android 5+ guidelines specify using a different color for the statusbar than your main app color (unlike the uniform statusbar color of many iOS 7+ apps), so you may want to set the statusbar color at runtime instead via `StatusBar.backgroundColorByHexString` or `StatusBar.backgroundColorByName`. One way to do that would be:
+```js
+if (cordova.platformId == 'android') {
+    StatusBar.backgroundColorByHexString("#333");
+}
+```
+
+Hiding at startup
+-----------
+
+During runtime you can use the StatusBar.hide function below, but if you want the StatusBar to be hidden at app startup, you must modify your app's Info.plist file.
+
+Add/edit these two attributes if not present. Set **"Status bar is initially hidden"** to **"YES"** and set **"View controller-based status bar appearance"** to **"NO"**. If you edit it manually without Xcode, the keys and values are:
+
+
+	<key>UIStatusBarHidden</key>
+	<true/>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+
+
+Methods
+-------
+This plugin defines global `StatusBar` object.
+
+Although in the global scope, it is not available until after the `deviceready` event.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+
+- StatusBar.overlaysWebView
+- StatusBar.styleDefault
+- StatusBar.styleLightContent
+- StatusBar.styleBlackTranslucent
+- StatusBar.styleBlackOpaque
+- StatusBar.backgroundColorByName
+- StatusBar.backgroundColorByHexString
+- StatusBar.hide
+- StatusBar.show
+
+Properties
+--------
+
+- StatusBar.isVisible
+
+Permissions
+-----------
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+
+StatusBar.overlaysWebView
+=================
+
+On iOS 7, make the statusbar overlay or not overlay the WebView.
+
+    StatusBar.overlaysWebView(true);
+
+Description
+-----------
+
+On iOS 7, set to false to make the statusbar appear like iOS 6. Set the style and background color to suit using the other functions.
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+Quick Example
+-------------
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+
+StatusBar.styleDefault
+=================
+
+Use the default statusbar (dark text, for light backgrounds).
+
+    StatusBar.styleDefault();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+- Windows Phone 7
+- Windows Phone 8
+- Windows Phone 8.1
+
+StatusBar.styleLightContent
+=================
+
+Use the lightContent statusbar (light text, for dark backgrounds).
+
+    StatusBar.styleLightContent();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+- Windows Phone 7
+- Windows Phone 8
+- Windows Phone 8.1
+
+StatusBar.styleBlackTranslucent
+=================
+
+Use the blackTranslucent statusbar (light text, for dark backgrounds).
+
+    StatusBar.styleBlackTranslucent();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+- Windows Phone 7
+- Windows Phone 8
+- Windows Phone 8.1
+
+StatusBar.styleBlackOpaque
+=================
+
+Use the blackOpaque statusbar (light text, for dark backgrounds).
+
+    StatusBar.styleBlackOpaque();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+- Windows Phone 7
+- Windows Phone 8
+- Windows Phone 8.1
+
+
+StatusBar.backgroundColorByName
+=================
+
+On iOS 7, when you set StatusBar.statusBarOverlaysWebView to false, you can set the background color of the statusbar by color name.
+
+    StatusBar.backgroundColorByName("red");
+
+Supported color names are:
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+
+
+Supported Platforms
+-------------------
+
+- iOS
+- Android 5+
+- Windows Phone 7
+- Windows Phone 8
+- Windows Phone 8.1
+
+StatusBar.backgroundColorByHexString
+=================
+
+Sets the background color of the statusbar by a hex string.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+
+CSS shorthand properties are also supported.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+
+On iOS 7, when you set StatusBar.statusBarOverlaysWebView to false, you can set the background color of the statusbar by a hex string (#RRGGBB).
+
+On WP7 and WP8 you can also specify values as #AARRGGBB, where AA is an alpha value
+
+Supported Platforms
+-------------------
+
+- iOS
+- Android 5+
+- Windows Phone 7
+- Windows Phone 8
+- Windows Phone 8.1
+
+StatusBar.hide
+=================
+
+Hide the statusbar.
+
+    StatusBar.hide();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+- Android
+- Windows Phone 7
+- Windows Phone 8
+- Windows Phone 8.1
+
+StatusBar.show
+=================
+
+Shows the statusbar.
+
+    StatusBar.show();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+- Android
+- Windows Phone 7
+- Windows Phone 8
+- Windows Phone 8.1
+
+
+StatusBar.isVisible
+=================
+
+Read this property to see if the statusbar is visible or not.
+
+    if (StatusBar.isVisible) {
+    	// do something
+    }
+
+
+Supported Platforms
+-------------------
+
+- iOS
+- Android
+- Windows Phone 7
+- Windows Phone 8
+- Windows Phone 8.1
+
+

--- a/plugins/cordova-plugin-statusbar/RELEASENOTES.md
+++ b/plugins/cordova-plugin-statusbar/RELEASENOTES.md
@@ -1,0 +1,88 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+-->
+# Release Notes
+
+### 0.1.5 (Apr 17, 2014) (First release as a core Cordova Plugin)
+* CB-6316: Added README.md which point to the new location for docs
+* CB-6316: Added license header to the documentation. Added README.md which point to the new location for docs
+* CB-6316: Moved StatusBar plugin documentation to docs folder
+* CB-6314: [android] Add StatusBar.isVisible support to Android
+* CB-6460: Update license headers
+
+### 0.1.6 (Jun 05, 2014)
+* CB-6783 - added StatusBarStyle config preference,  updated docs (closes #9)
+* CB-6812 Add license
+* CB-6491 add CONTRIBUTING.md
+* CB-6264 minor formatting issue
+* Update docs with recent WP changes, remove 'clear' from the loist of named colors in documentation
+* CB-6513 - Statusbar plugin for Android is not compiling
+
+### 0.1.7 (Aug 06, 2014)
+* Add LICENSE and NOTICE
+* Update statusbar.js
+* Update backgroundColorByHexString function
+* ios: Use a persistent callbackId instead of calling sendJs
+* CB-6626 ios: Add a JS event for tapping on statusbar
+* ios: Fix hide to adjust webview's frame only when status bar is not overlaying webview
+* CB-6127 Updated translations for docs
+* android: Fix StatusBar.initialize() not running on UI thread
+
+### 0.1.8 (Sep 17, 2014)
+* CB-7549 [StatusBar][iOS 8] Landscape issue
+* CB-7486 Remove StatusBarBackgroundColor intial preference (black background) so background will be initially transparent
+* Renamed test dir, added nested plugin.xml
+* added documentation for manual tests, moved background color test below overlay test
+* CB-7195 ported statusbar tests to framework
+
+### 0.1.9 (Dec 02, 2014)
+* Fix onload attribute within <feature> to be a <param>
+* CB-8010 - Statusbar colour does not change to orange
+* added checks for running on windows when StatusBar is NOT available
+* CB-7986 Add cordova-plugin-statusbar support for **Windows Phone 8.1**
+* CB-7977 Mention `deviceready` in plugin docs
+* CB-7979 Each plugin doc should have a ## Installation section
+* Inserting leading space after # for consistency
+* CB-7549 - (Re-fix) `StatusBar` **iOS 8** Landscape issue (closes #15)
+* CB-7700 cordova-plugin-statusbar documentation translation: cordova-plugin-statusbar
+* CB-7571 Bump version of nested plugin to match parent plugin
+
+### 0.1.10 (Feb 04, 2015)
+* CB-8351 ios: Use argumentForIndex rather than NSArray extension
+
+### 1.0.0 (Apr 15, 2015)
+* CB-8746 gave plugin major version bump
+* CB-8683 changed plugin-id to pacakge-name
+* CB-8653 properly updated translated docs to use new id
+* CB-8653 updated translated docs to use new id
+* Use TRAVIS_BUILD_DIR, install paramedic by npm
+* CB-8653 Updated Readme
+* - Use StatusBarBackgroundColor instead of AndroidStatusBarBackgroundColor, and added a quirk to the readme.
+* - Add support for StatusBar.backgroundColorByHexString (and StatusBar.backgroundColorByName) on Android 5 and up
+* Allow setting the statusbar backgroundcolor on Android
+* CB-8575 Integrate TravisCI
+* CB-8438 cordova-plugin-statusbar documentation translation: cordova-plugin-statusbar
+* CB-8538 Added package.json file
+
+### 1.0.1 (Jun 17, 2015)
+* add auto-tests for basic api
+* CB-9180 Add correct supported check for Windows 8.1 desktop
+* CB-9128 cordova-plugin-statusbar documentation translation: cordova-plugin-statusbar
+* fix npm md issue

--- a/plugins/cordova-plugin-statusbar/doc/de/README.md
+++ b/plugins/cordova-plugin-statusbar/doc/de/README.md
@@ -1,0 +1,276 @@
+<!---
+# license: Licensed to the Apache Software Foundation (ASF) under one
+#         or more contributor license agreements.  See the NOTICE file
+#         distributed with this work for additional information
+#         regarding copyright ownership.  The ASF licenses this file
+#         to you under the Apache License, Version 2.0 (the
+#         "License"); you may not use this file except in compliance
+#         with the License.  You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#         Unless required by applicable law or agreed to in writing,
+#         software distributed under the License is distributed on an
+#         "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#         KIND, either express or implied.  See the License for the
+#         specific language governing permissions and limitations
+#         under the License.
+-->
+
+# cordova-plugin-statusbar
+
+[![Build Status](https://travis-ci.org/apache/cordova-plugin-statusbar.svg)](https://travis-ci.org/apache/cordova-plugin-statusbar)
+
+# StatusBar
+
+> Das `StatusBar` Objekt stellt einige Funktionen zum Anpassen des iOS und Android StatusBar.
+
+## Installation
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## "Einstellungen"
+
+#### "config.xml"
+
+  * **StatusBarOverlaysWebView** (Boolean, der Standardwert ist True). Stellen Sie auf iOS 7 die Statusbar-Overlay oder keine Überlagerung der WebView beim Start.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+  * **StatusBarBackgroundColor** (Farbe hex String, Standardwert ist #000000). Auf iOS legen 7 und Android 5, Sie die Hintergrundfarbe der Statusbar von eine hexadezimale Zeichenfolge (#RRGGBB) beim Start.
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+  * **StatusBarStyle** (Status Bar-Stil, der Standardwert ist Lightcontent). Legen Sie auf iOS 7 den Status-Bar-Stil. Verfügbaren Optionen Standard, Lightcontent, Blacktranslucent, Blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+### Android Eigenarten
+
+Die Android 5 + Leitlinien angeben, verwenden eine andere Farbe für die Statusbar als Ihre Hauptanwendung Farbe (anders als die einheitliche Statusbar Farbe viele iOS 7 + apps), so Sie die Statusbar Farbe zur Laufzeit statt über `StatusBar.backgroundColorByHexString` oder `StatusBar.backgroundColorByName`festzulegen möchten vielleicht. Eine Möglichkeit dazu wäre:
+
+```js
+if (cordova.platformId == 'android') {
+    StatusBar.backgroundColorByHexString("#333");
+}
+```
+
+## Beim Start ausblenden
+
+Während der Laufzeit können Sie die StatusBar.hide-Funktion unten, aber die StatusBar beim Start der app versteckt werden soll, müssen Sie Ihre app Info.plist Datei ändern.
+
+Diese beiden Attribute hinzufügen/bearbeiten, wenn nicht vorhanden. Legen Sie **"Statusleiste ist anfangs ausgeblendet"** auf **"YES"** und **"View Controller-basierte Status Bar aussehen"** auf **"NO"**. Wenn Sie es manuell ohne Xcode bearbeiten, werden die Schlüssel und Werte:
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## Methoden
+
+Dieses Plugin wird globales `StatusBar`-Objekt definiert.
+
+Obwohl im globalen Gültigkeitsbereich, steht es nicht bis nach dem `deviceready`-Ereignis.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+  * StatusBar.overlaysWebView
+  * StatusBar.styleDefault
+  * StatusBar.styleLightContent
+  * StatusBar.styleBlackTranslucent
+  * StatusBar.styleBlackOpaque
+  * StatusBar.backgroundColorByName
+  * StatusBar.backgroundColorByHexString
+  * StatusBar.hide
+  * StatusBar.show
+
+## Eigenschaften
+
+  * StatusBar.isVisible
+
+## Berechtigungen
+
+#### "config.xml"
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+Stellen Sie auf iOS 7 Statusbar überlagern oder nicht überlagert die WebView.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## Beschreibung
+
+Auf iOS 7 zu der Statusbar wie iOS 6 erscheinen auf False festgelegt. Legen Sie die Stil und Hintergrund Farbe entsprechend mit den anderen Funktionen.
+
+## Unterstützte Plattformen
+
+  * iOS
+
+## Kurzes Beispiel
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+Verwenden Sie die Standard-Statusbar (dunkle Text, für helle Hintergründe).
+
+    StatusBar.styleDefault();
+    
+
+## Unterstützte Plattformen
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone-8.1
+
+# StatusBar.styleLightContent
+
+Verwenden Sie die LightContent-Statusbar (heller Text, für dunkle Hintergründe).
+
+    StatusBar.styleLightContent();
+    
+
+## Unterstützte Plattformen
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone-8.1
+
+# StatusBar.styleBlackTranslucent
+
+Verwenden Sie die BlackTranslucent-Statusbar (heller Text, für dunkle Hintergründe).
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## Unterstützte Plattformen
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone-8.1
+
+# StatusBar.styleBlackOpaque
+
+Verwenden Sie die BlackOpaque-Statusbar (heller Text, für dunkle Hintergründe).
+
+    StatusBar.styleBlackOpaque();
+    
+
+## Unterstützte Plattformen
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone-8.1
+
+# StatusBar.backgroundColorByName
+
+Auf iOS 7 Wenn Sie StatusBar.statusBarOverlaysWebView auf False festlegen, können Sie die Hintergrundfarbe der Statusbar von Farbnamen festlegen.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+Unterstützte Farbnamen sind:
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## Unterstützte Plattformen
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone-8.1
+
+# StatusBar.backgroundColorByHexString
+
+Legt die Hintergrundfarbe der Statusbar von eine hexadezimale Zeichenfolge fest.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+CSS-Kurzschrift-Eigenschaften werden ebenfalls unterstützt.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+Auf iOS 7 Wenn Sie StatusBar.statusBarOverlaysWebView auf False festlegen, können Sie die Hintergrundfarbe der Statusbar von eine hexadezimale Zeichenfolge (#RRGGBB) festlegen.
+
+Auf WP7 und WP8 können Sie auch Werte wie #AARRGGBB, angeben wo AA einen alpha-Wert ist
+
+## Unterstützte Plattformen
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone-8.1
+
+# StatusBar.hide
+
+Ausblenden der Statusleiste.
+
+    StatusBar.hide();
+    
+
+## Unterstützte Plattformen
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone-8.1
+
+# StatusBar.show
+
+Zeigt die Statusleiste.
+
+    StatusBar.show();
+    
+
+## Unterstützte Plattformen
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone-8.1
+
+# StatusBar.isVisible
+
+Lesen Sie diese Eigenschaft, um festzustellen, ob die Statusbar sichtbar oder nicht ist.
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## Unterstützte Plattformen
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone-8.1

--- a/plugins/cordova-plugin-statusbar/doc/de/index.md
+++ b/plugins/cordova-plugin-statusbar/doc/de/index.md
@@ -1,0 +1,262 @@
+<!---
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# cordova-plugin-statusbar
+
+# StatusBar
+
+> Das `StatusBar` Objekt stellt einige Funktionen zum Anpassen des iOS und Android StatusBar.
+
+## Installation
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## "Einstellungen"
+
+#### config.xml
+
+*   **StatusBarOverlaysWebView** (Boolean, der Standardwert ist True). Stellen Sie auf iOS 7 die Statusbar-Overlay oder keine Überlagerung der WebView beim Start.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+*   **StatusBarBackgroundColor** (Farbe hex String, der Standardwert ist #000000). Legen Sie auf iOS 7 die Hintergrundfarbe der Statusbar von eine hexadezimale Zeichenfolge (#RRGGBB) beim Start.
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+*   **StatusBarStyle** (Status Bar-Stil, der Standardwert ist Lightcontent). Legen Sie auf iOS 7 den Status-Bar-Stil. Verfügbaren Optionen Standard, Lightcontent, Blacktranslucent, Blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+## Beim Start ausblenden
+
+Während der Laufzeit können Sie die StatusBar.hide-Funktion unten, aber die StatusBar beim Start der app versteckt werden soll, müssen Sie Ihre app Info.plist Datei ändern.
+
+Diese beiden Attribute hinzufügen/bearbeiten, wenn nicht vorhanden. Legen Sie **"Statusleiste ist anfangs ausgeblendet"** auf **"YES"** und **"View Controller-basierte Status Bar aussehen"** auf **"NO"**. Wenn Sie es manuell ohne Xcode bearbeiten, werden die Schlüssel und Werte:
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## Methoden
+
+Dieses Plugin wird globales `StatusBar`-Objekt definiert.
+
+Obwohl im globalen Gültigkeitsbereich, steht es nicht bis nach dem `deviceready`-Ereignis.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+*   StatusBar.overlaysWebView
+*   StatusBar.styleDefault
+*   StatusBar.styleLightContent
+*   StatusBar.styleBlackTranslucent
+*   StatusBar.styleBlackOpaque
+*   StatusBar.backgroundColorByName
+*   StatusBar.backgroundColorByHexString
+*   StatusBar.hide
+*   StatusBar.show
+
+## Eigenschaften
+
+*   StatusBar.isVisible
+
+## Berechtigungen
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+Stellen Sie auf iOS 7 Statusbar überlagern oder nicht überlagert die WebView.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## Beschreibung
+
+Auf iOS 7 zu der Statusbar wie iOS 6 erscheinen auf False festgelegt. Legen Sie die Stil und Hintergrund Farbe entsprechend mit den anderen Funktionen.
+
+## Unterstützte Plattformen
+
+*   iOS
+
+## Kurzes Beispiel
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+Verwenden Sie die Standard-Statusbar (dunkle Text, für helle Hintergründe).
+
+    StatusBar.styleDefault();
+    
+
+## Unterstützte Plattformen
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone-8.1
+
+# StatusBar.styleLightContent
+
+Verwenden Sie die LightContent-Statusbar (heller Text, für dunkle Hintergründe).
+
+    StatusBar.styleLightContent();
+    
+
+## Unterstützte Plattformen
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone-8.1
+
+# StatusBar.styleBlackTranslucent
+
+Verwenden Sie die BlackTranslucent-Statusbar (heller Text, für dunkle Hintergründe).
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## Unterstützte Plattformen
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone-8.1
+
+# StatusBar.styleBlackOpaque
+
+Verwenden Sie die BlackOpaque-Statusbar (heller Text, für dunkle Hintergründe).
+
+    StatusBar.styleBlackOpaque();
+    
+
+## Unterstützte Plattformen
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone-8.1
+
+# StatusBar.backgroundColorByName
+
+Auf iOS 7 Wenn Sie StatusBar.statusBarOverlaysWebView auf False festlegen, können Sie die Hintergrundfarbe der Statusbar von Farbnamen festlegen.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+Unterstützte Farbnamen sind:
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## Unterstützte Plattformen
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone-8.1
+
+# StatusBar.backgroundColorByHexString
+
+Legt die Hintergrundfarbe der Statusbar von eine hexadezimale Zeichenfolge fest.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+CSS-Kurzschrift-Eigenschaften werden ebenfalls unterstützt.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+Auf iOS 7 Wenn Sie StatusBar.statusBarOverlaysWebView auf False festlegen, können Sie die Hintergrundfarbe der Statusbar von eine hexadezimale Zeichenfolge (#RRGGBB) festlegen.
+
+Auf WP7 und WP8 können Sie auch Werte wie #AARRGGBB, angeben wo AA einen alpha-Wert ist
+
+## Unterstützte Plattformen
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone-8.1
+
+# StatusBar.hide
+
+Ausblenden der Statusleiste.
+
+    StatusBar.hide();
+    
+
+## Unterstützte Plattformen
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone-8.1
+
+# StatusBar.show
+
+Zeigt die Statusleiste.
+
+    StatusBar.show();
+    
+
+## Unterstützte Plattformen
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone-8.1
+
+# StatusBar.isVisible
+
+Lesen Sie diese Eigenschaft, um festzustellen, ob die Statusbar sichtbar oder nicht ist.
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## Unterstützte Plattformen
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone-8.1

--- a/plugins/cordova-plugin-statusbar/doc/es/README.md
+++ b/plugins/cordova-plugin-statusbar/doc/es/README.md
@@ -1,0 +1,276 @@
+<!---
+# license: Licensed to the Apache Software Foundation (ASF) under one
+#         or more contributor license agreements.  See the NOTICE file
+#         distributed with this work for additional information
+#         regarding copyright ownership.  The ASF licenses this file
+#         to you under the Apache License, Version 2.0 (the
+#         "License"); you may not use this file except in compliance
+#         with the License.  You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#         Unless required by applicable law or agreed to in writing,
+#         software distributed under the License is distributed on an
+#         "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#         KIND, either express or implied.  See the License for the
+#         specific language governing permissions and limitations
+#         under the License.
+-->
+
+# cordova-plugin-statusbar
+
+[![Build Status](https://travis-ci.org/apache/cordova-plugin-statusbar.svg)](https://travis-ci.org/apache/cordova-plugin-statusbar)
+
+# StatusBar
+
+> El `StatusBar` objeto proporciona algunas funciones para personalizar el iOS y Android StatusBar.
+
+## Instalación
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## Preferencias
+
+#### config.xml
+
+  * **StatusBarOverlaysWebView** (boolean, true por defecto). En iOS 7, hacer la superposición statusbar o no superponer la WebView al inicio.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+  * **StatusBarBackgroundColor** (color hex string por defecto #000000). IOS 7 y 5 Android, configurar el color de fondo de la barra de estado por una cadena hexadecimal (#RRGGBB) en el arranque.
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+  * **StatusBarStyle** (status bar estilo por defecto lightcontent). En iOS 7, definir el estilo de barra de estado. Por defecto las opciones disponibles, lightcontent, blacktranslucent, blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+### Rarezas Android
+
+Android 5 + pautas especifican utilizando un color diferente para la barra de estado que la aplicación principal de color (a diferencia del color de barra de estado uniforme de muchas apps de iOS 7 +), por lo que puede establecer el color de la barra de estado en tiempo de ejecución en su lugar a través de `StatusBar.backgroundColorByHexString` o `StatusBar.backgroundColorByName`. Una forma de hacerlo sería:
+
+```js
+if (cordova.platformId == 'android') {
+    StatusBar.backgroundColorByHexString("#333");
+}
+```
+
+## Escondido en el arranque
+
+Durante el tiempo de ejecución puede utilizar la función StatusBar.hide abajo, pero si quieres la barra de estado que está escondido en el inicio de la aplicación, se debe modificar el archivo Info.plist de su aplicación.
+
+Agregar/editar estos dos atributos si no está presente. Defina **"inicialmente se esconde la barra de estado"** a **"YES"** y **"Aparición de vista basado en controlador estatus bar"** a **"NO"**. Si se edita manualmente sin Xcode, las claves y valores son:
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## Métodos
+
+Este plugin define global `StatusBar` objeto.
+
+Aunque en el ámbito global, no estará disponible hasta después de la `deviceready` evento.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+  * StatusBar.overlaysWebView
+  * StatusBar.styleDefault
+  * StatusBar.styleLightContent
+  * StatusBar.styleBlackTranslucent
+  * StatusBar.styleBlackOpaque
+  * StatusBar.backgroundColorByName
+  * StatusBar.backgroundColorByHexString
+  * StatusBar.hide
+  * StatusBar.show
+
+## Propiedades
+
+  * StatusBar.isVisible
+
+## Permisos
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+En iOS 7, hacer la barra de estado superposición o no superponer la vista Web.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## Descripción
+
+En iOS 7, establecida en false para que la barra de estado aparezca como iOS 6. Establece el color de fondo y estilo para utilizar las otras funciones.
+
+## Plataformas soportadas
+
+  * iOS
+
+## Ejemplo rápido
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+Utilice la barra de estado por defecto (texto oscuro, para fondos de luz).
+
+    StatusBar.styleDefault();
+    
+
+## Plataformas soportadas
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+Utilice la barra de estado lightContent (texto ligero, para fondos oscuros).
+
+    StatusBar.styleLightContent();
+    
+
+## Plataformas soportadas
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+Utilice la barra de estado blackTranslucent (texto ligero, para fondos oscuros).
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## Plataformas soportadas
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+Utilice la barra de estado blackOpaque (texto ligero, para fondos oscuros).
+
+    StatusBar.styleBlackOpaque();
+    
+
+## Plataformas soportadas
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+En iOS 7, al establecer StatusBar.statusBarOverlaysWebView a false, se puede establecer el color de fondo de la barra de estado nombre del color.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+Nombres de los colores admitidos son:
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## Plataformas soportadas
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+Establece el color de fondo de la barra de estado por una cadena hexadecimal.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+Propiedades CSS abreviada también son compatibles.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+En iOS 7, cuando se establece StatusBar.statusBarOverlaysWebView en false, se puede establecer el color de fondo de la barra de estado una cadena hexadecimal (#RRGGBB).
+
+En WP7 y WP8 también puede especificar valores como #AARRGGBB, donde AA es un valor alfa
+
+## Plataformas soportadas
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.hide
+
+Ocultar la barra de estado.
+
+    StatusBar.hide();
+    
+
+## Plataformas soportadas
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.show
+
+Muestra la barra de estado.
+
+    StatusBar.show();
+    
+
+## Plataformas soportadas
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.isVisible
+
+Lea esta propiedad para ver si la barra de estado es visible o no.
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## Plataformas soportadas
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/es/index.md
+++ b/plugins/cordova-plugin-statusbar/doc/es/index.md
@@ -1,0 +1,252 @@
+<!---
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# cordova-plugin-statusbar
+
+# StatusBar
+
+> El `StatusBar` objeto proporciona algunas funciones para personalizar el iOS y Android StatusBar.
+
+## Instalación
+
+    Cordova plugin agregar cordova-plugin-statusbar
+    
+
+## Preferencias
+
+#### config.xml
+
+*   **StatusBarOverlaysWebView** (boolean, true por defecto). En iOS 7, hacer la superposición statusbar o no superponer la WebView al inicio.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+*   **StatusBarBackgroundColor** (cadena hexadecimal color, #000000 por defecto). En iOS 7, establecer el color de fondo de la barra de estado por una cadena hexadecimal (#RRGGBB) en el arranque.
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+*   **StatusBarStyle** (status bar estilo por defecto lightcontent). En iOS 7, definir el estilo de barra de estado. Por defecto las opciones disponibles, lightcontent, blacktranslucent, blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+## Escondido en el arranque
+
+Durante el tiempo de ejecución puede utilizar la función StatusBar.hide abajo, pero si quieres la barra de estado que está escondido en el inicio de la aplicación, se debe modificar el archivo Info.plist de su aplicación.
+
+Agregar/editar estos dos atributos si no está presente. Defina **"inicialmente se esconde la barra de estado"** a **"YES"** y **"Aparición de vista basado en controlador estatus bar"** a **"NO"**. Si se edita manualmente sin Xcode, las claves y valores son:
+
+    < llave > UIStatusBarHidden < / key >< verdadero / >< llave > UIViewControllerBasedStatusBarAppearance < / key >< falso / >
+    
+
+## Métodos
+
+Este plugin define global `StatusBar` objeto.
+
+Aunque en el ámbito global, no estará disponible hasta después de la `deviceready` evento.
+
+    document.addEventListener ("deviceready", onDeviceReady, false);
+    function onDeviceReady() {console.log(StatusBar)};
+    
+
+*   StatusBar.overlaysWebView
+*   StatusBar.styleDefault
+*   StatusBar.styleLightContent
+*   StatusBar.styleBlackTranslucent
+*   StatusBar.styleBlackOpaque
+*   StatusBar.backgroundColorByName
+*   StatusBar.backgroundColorByHexString
+*   StatusBar.hide
+*   StatusBar.show
+
+## Propiedades
+
+*   StatusBar.isVisible
+
+## Permisos
+
+#### config.xml
+
+            < nombre de la función = "StatusBar" >< nombre param = "ios-paquete" value = "CDVStatusBar" onload = "true" / >< / característica >
+    
+
+# StatusBar.overlaysWebView
+
+En iOS 7, hacer la barra de estado superposición o no superponer la vista Web.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## Descripción
+
+En iOS 7, establecida en false para que la barra de estado aparezca como iOS 6. Establece el color de fondo y estilo para utilizar las otras funciones.
+
+## Plataformas soportadas
+
+*   iOS
+
+## Ejemplo rápido
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+Utilice la barra de estado por defecto (texto oscuro, para fondos de luz).
+
+    StatusBar.styleDefault();
+    
+
+## Plataformas soportadas
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+Utilice la barra de estado lightContent (texto ligero, para fondos oscuros).
+
+    StatusBar.styleLightContent();
+    
+
+## Plataformas soportadas
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+Utilice la barra de estado blackTranslucent (texto ligero, para fondos oscuros).
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## Plataformas soportadas
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+Utilice la barra de estado blackOpaque (texto ligero, para fondos oscuros).
+
+    StatusBar.styleBlackOpaque();
+    
+
+## Plataformas soportadas
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+En iOS 7, al establecer StatusBar.statusBarOverlaysWebView a false, se puede establecer el color de fondo de la barra de estado nombre del color.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+Nombres de los colores admitidos son:
+
+    negro, gris oscuro, lightGray, blanco, gris, rojo, verde, azul, cian, amarillo, magenta, naranja, púrpura, marrón
+    
+
+## Plataformas soportadas
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+Establece el color de fondo de la barra de estado por una cadena hexadecimal.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+Propiedades CSS abreviada también son compatibles.
+
+    StatusBar.backgroundColorByHexString("#333"); = > StatusBar.backgroundColorByHexString("#FAB") #333333; = > #FFAABB
+    
+
+En iOS 7, cuando se establece StatusBar.statusBarOverlaysWebView en false, se puede establecer el color de fondo de la barra de estado una cadena hexadecimal (#RRGGBB).
+
+En WP7 y WP8 también puede especificar valores como #AARRGGBB, donde AA es un valor alfa
+
+## Plataformas soportadas
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.hide
+
+Ocultar la barra de estado.
+
+    StatusBar.hide();
+    
+
+## Plataformas soportadas
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.show
+
+Muestra la barra de estado.
+
+    StatusBar.show();
+    
+
+## Plataformas soportadas
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.isVisible
+
+Lea esta propiedad para ver si la barra de estado es visible o no.
+
+    Si (StatusBar.isVisible) {/ / hacer algo}
+    
+
+## Plataformas soportadas
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/fr/README.md
+++ b/plugins/cordova-plugin-statusbar/doc/fr/README.md
@@ -1,0 +1,276 @@
+<!---
+# license: Licensed to the Apache Software Foundation (ASF) under one
+#         or more contributor license agreements.  See the NOTICE file
+#         distributed with this work for additional information
+#         regarding copyright ownership.  The ASF licenses this file
+#         to you under the Apache License, Version 2.0 (the
+#         "License"); you may not use this file except in compliance
+#         with the License.  You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#         Unless required by applicable law or agreed to in writing,
+#         software distributed under the License is distributed on an
+#         "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#         KIND, either express or implied.  See the License for the
+#         specific language governing permissions and limitations
+#         under the License.
+-->
+
+# cordova-plugin-statusbar
+
+[![Build Status](https://travis-ci.org/apache/cordova-plugin-statusbar.svg)](https://travis-ci.org/apache/cordova-plugin-statusbar)
+
+# StatusBar
+
+> Le `StatusBar` objet fournit quelques fonctions pour personnaliser les iOS et Android StatusBar.
+
+## Installation
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## Préférences
+
+#### config.Xml
+
+  * **StatusBarOverlaysWebView** (boolean, la valeur par défaut true). Sur iOS 7, faire la superposition de statusbar ou pas superposition le WebView au démarrage.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+  * **StatusBarBackgroundColor** (chaîne hexadécimale de couleur, par défaut, #000000). Sur iOS 7 et 5 Android, définir la couleur d'arrière-plan de la barre d'État par une chaîne hexadécimale (#RRGGBB) au démarrage.
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+  * **StatusBarStyle** (style de barre de statut, par défaut, lightcontent). Sur iOS 7, définir le style de barre de statut. Par défaut les options disponibles, lightcontent, blacktranslucent, blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+### Quirks Android
+
+Les lignes directrices 5 + Android spécifient à l'aide d'une couleur différente pour la barre d'État à votre application principale couleur (contrairement à la couleur uniforme statusbar de nombreuses applications iOS 7 +), donc vous pouvez définir la couleur de la barre d'état lors de l'exécution au lieu de cela via `StatusBar.backgroundColorByHexString` ou `StatusBar.backgroundColorByName`. Une façon de le faire serait :
+
+```js
+if (cordova.platformId == 'android') {
+    StatusBar.backgroundColorByHexString("#333");
+}
+```
+
+## Cacher au démarrage
+
+Pendant l'exécution, vous pouvez utiliser la fonction StatusBar.hide en bas, mais si vous souhaitez que la barre d'État pour être caché au démarrage de l'application, vous devez modifier le fichier Info.plist de votre application.
+
+Ajouter/modifier ces deux attributs si n'est pas présent. **"Barre d'État est initialement masqué"** la valeur **"** Yes" et **"À l'apparence vue sur contrôleur statut bar"** la valeur **"Non"**. Si vous modifiez manuellement sans Xcode, les clés et les valeurs sont :
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## Méthodes
+
+Ce plugin définit objet `StatusBar` global.
+
+Bien que dans la portée globale, il n'est pas disponible jusqu'après la `deviceready` événement.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+  * StatusBar.overlaysWebView
+  * StatusBar.styleDefault
+  * StatusBar.styleLightContent
+  * StatusBar.styleBlackTranslucent
+  * StatusBar.styleBlackOpaque
+  * StatusBar.backgroundColorByName
+  * StatusBar.backgroundColorByHexString
+  * StatusBar.hide
+  * StatusBar.show
+
+## Propriétés
+
+  * StatusBar.isVisible
+
+## Autorisations
+
+#### config.Xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+Sur iOS 7, faire la statusbar superposition ou pas superposer le WebView.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## Description
+
+Sur iOS 7, la valeur false pour afficher la barre d'État comme iOS 6. Définissez la couleur de style et d'arrière-plan en fonction de l'utilisation des autres fonctions.
+
+## Plates-formes supportées
+
+  * iOS
+
+## Exemple court
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+Utilisez la barre de statut par défaut (texte sombre, pour les arrière-plans lumineux).
+
+    StatusBar.styleDefault();
+    
+
+## Plates-formes supportées
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+Utilisez la barre d'État lightContent (texte clair, des arrière-plans sombres).
+
+    StatusBar.styleLightContent();
+    
+
+## Plates-formes supportées
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+Utilisez la barre d'État blackTranslucent (texte clair, des arrière-plans sombres).
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## Plates-formes supportées
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+Utilisez la barre d'État blackOpaque (texte clair, des arrière-plans sombres).
+
+    StatusBar.styleBlackOpaque();
+    
+
+## Plates-formes supportées
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+Sur iOS 7, lorsque vous définissez StatusBar.statusBarOverlaysWebView sur false, vous pouvez définir la couleur d'arrière-plan de la barre d'État par nom de couleur.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+Les noms de couleurs prises en charge sont :
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## Plates-formes supportées
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+Définit la couleur d'arrière-plan de la barre d'État par une chaîne hexadécimale.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+Propriétés de raccourci CSS sont également pris en charge.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+Sur iOS 7, lorsque vous définissez StatusBar.statusBarOverlaysWebView sur false, vous pouvez définir la couleur d'arrière-plan de la barre d'État par une chaîne hexadécimale (#RRGGBB).
+
+Sur WP7 et WP8, vous pouvez également spécifier des valeurs comme #AARRGGBB, où AA représente une valeur alpha
+
+## Plates-formes supportées
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.hide
+
+Masquer la barre d'État.
+
+    StatusBar.hide();
+    
+
+## Plates-formes supportées
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.show
+
+Affiche la barre d'État.
+
+    StatusBar.show();
+    
+
+## Plates-formes supportées
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.isVisible
+
+Lire cette propriété afin de voir si la barre d'État est visible ou non.
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## Plates-formes supportées
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/fr/index.md
+++ b/plugins/cordova-plugin-statusbar/doc/fr/index.md
@@ -1,0 +1,262 @@
+<!---
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# cordova-plugin-statusbar
+
+# StatusBar
+
+> Le `StatusBar` objet fournit quelques fonctions pour personnaliser les iOS et Android StatusBar.
+
+## Installation
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## Préférences
+
+#### config.xml
+
+*   **StatusBarOverlaysWebView** (boolean, la valeur par défaut true). Sur iOS 7, faire la superposition de statusbar ou pas superposition le WebView au démarrage.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+*   **StatusBarBackgroundColor** (chaîne hexadécimale de couleur, par défaut, #000000). Sur iOS 7, définir la couleur d'arrière-plan de la barre d'État par une chaîne hexadécimale (#RRGGBB) au démarrage.
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+*   **StatusBarStyle** (style de barre de statut, par défaut, lightcontent). Sur iOS 7, définir le style de barre de statut. Par défaut les options disponibles, lightcontent, blacktranslucent, blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+## Cacher au démarrage
+
+Pendant l'exécution, vous pouvez utiliser la fonction StatusBar.hide en bas, mais si vous souhaitez que la barre d'État pour être caché au démarrage de l'application, vous devez modifier le fichier Info.plist de votre application.
+
+Ajouter/modifier ces deux attributs si n'est pas présent. **"Barre d'État est initialement masqué"** la valeur **"** Yes" et **"À l'apparence vue sur contrôleur statut bar"** la valeur **"Non"**. Si vous modifiez manuellement sans Xcode, les clés et les valeurs sont :
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## Méthodes
+
+Ce plugin définit objet `StatusBar` global.
+
+Bien que dans la portée globale, il n'est pas disponible jusqu'après la `deviceready` événement.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+*   StatusBar.overlaysWebView
+*   StatusBar.styleDefault
+*   StatusBar.styleLightContent
+*   StatusBar.styleBlackTranslucent
+*   StatusBar.styleBlackOpaque
+*   StatusBar.backgroundColorByName
+*   StatusBar.backgroundColorByHexString
+*   StatusBar.hide
+*   StatusBar.show
+
+## Propriétés
+
+*   StatusBar.isVisible
+
+## Autorisations
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+Sur iOS 7, faire la statusbar superposition ou pas superposer le WebView.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## Description
+
+Sur iOS 7, la valeur false pour afficher la barre d'État comme iOS 6. Définissez la couleur de style et d'arrière-plan en fonction de l'utilisation des autres fonctions.
+
+## Plates-formes supportées
+
+*   iOS
+
+## Exemple court
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+Utilisez la barre de statut par défaut (texte sombre, pour les arrière-plans lumineux).
+
+    StatusBar.styleDefault();
+    
+
+## Plates-formes prises en charge
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+Utilisez la barre d'État lightContent (texte clair, des arrière-plans sombres).
+
+    StatusBar.styleLightContent();
+    
+
+## Plates-formes prises en charge
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+Utilisez la barre d'État blackTranslucent (texte clair, des arrière-plans sombres).
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## Plates-formes prises en charge
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+Utilisez la barre d'État blackOpaque (texte clair, des arrière-plans sombres).
+
+    StatusBar.styleBlackOpaque();
+    
+
+## Plates-formes prises en charge
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+Sur iOS 7, lorsque vous définissez StatusBar.statusBarOverlaysWebView sur false, vous pouvez définir la couleur d'arrière-plan de la barre d'État par nom de couleur.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+Les noms de couleurs prises en charge sont :
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## Plates-formes prises en charge
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+Définit la couleur d'arrière-plan de la barre d'État par une chaîne hexadécimale.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+Propriétés de raccourci CSS sont également pris en charge.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+Sur iOS 7, lorsque vous définissez StatusBar.statusBarOverlaysWebView sur false, vous pouvez définir la couleur d'arrière-plan de la barre d'État par une chaîne hexadécimale (#RRGGBB).
+
+Sur WP7 et WP8, vous pouvez également spécifier des valeurs comme #AARRGGBB, où AA représente une valeur alpha
+
+## Plates-formes prises en charge
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.hide
+
+Masquer la barre d'État.
+
+    StatusBar.hide();
+    
+
+## Plates-formes prises en charge
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.show
+
+Affiche la barre d'État.
+
+    StatusBar.show();
+    
+
+## Plates-formes prises en charge
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.isVisible
+
+Lire cette propriété afin de voir si la barre d'État est visible ou non.
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## Plates-formes supportées
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/it/README.md
+++ b/plugins/cordova-plugin-statusbar/doc/it/README.md
@@ -1,0 +1,276 @@
+<!---
+# license: Licensed to the Apache Software Foundation (ASF) under one
+#         or more contributor license agreements.  See the NOTICE file
+#         distributed with this work for additional information
+#         regarding copyright ownership.  The ASF licenses this file
+#         to you under the Apache License, Version 2.0 (the
+#         "License"); you may not use this file except in compliance
+#         with the License.  You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#         Unless required by applicable law or agreed to in writing,
+#         software distributed under the License is distributed on an
+#         "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#         KIND, either express or implied.  See the License for the
+#         specific language governing permissions and limitations
+#         under the License.
+-->
+
+# cordova-plugin-statusbar
+
+[![Build Status](https://travis-ci.org/apache/cordova-plugin-statusbar.svg)](https://travis-ci.org/apache/cordova-plugin-statusbar)
+
+# StatusBar
+
+> Il `StatusBar` oggetto fornisce alcune funzioni per personalizzare l'iOS e Android StatusBar.
+
+## Installazione
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## Preferenze
+
+#### config. XML
+
+  * **StatusBarOverlaysWebView** (boolean, default è true). IOS 7, rendono la statusbar sovrapposizione o la non sovrapposizione WebView all'avvio.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+  * **StatusBarBackgroundColor** (stringa esadecimale di colore, il valore predefinito è #000000). Su iOS 7 e 5 Android, è possibile impostare il colore di sfondo della barra di stato di una stringa esadecimale (#RRGGBB) all'avvio.
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+  * **StatusBarStyle** (status bar in stile, default è lightcontent). IOS 7, impostare lo stile di barra di stato. Predefinita di opzioni disponibili, lightcontent, blacktranslucent, blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+### Stranezze Android
+
+Le linee 5 + Android Guida specificano utilizzando un colore diverso per la barra di stato che l'app principale di colore (a differenza di colore uniforme statusbar di molte applicazioni di iOS 7 +), quindi si consiglia di impostare il colore della barra di stato in fase di esecuzione invece tramite `StatusBar.backgroundColorByHexString` o `StatusBar.backgroundColorByName`. Un modo per farlo sarebbe:
+
+```js
+if (cordova.platformId == 'android') {
+    StatusBar.backgroundColorByHexString("#333");
+}
+```
+
+## Nascondendo all'avvio
+
+In fase di esecuzione è possibile utilizzare la funzione di StatusBar.hide qui sotto, ma se si desidera che la barra di stato venga nascosta all'avvio di app, è necessario modificare il file info. plist dell'app.
+
+Aggiungere o modificare questi due attributi, se non presente. Impostare la **"barra di stato è inizialmente nascosto"** a **"YES"** e **"Aspetto di vista basati su controller status bar"** a **"NO"**. Se si modifica manualmente senza Xcode, le chiavi e i valori sono:
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## Metodi
+
+Questo plugin definisce globale oggetto `StatusBar`.
+
+Anche se in ambito globale, non è disponibile fino a dopo l'evento `deviceready`.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+  * StatusBar.overlaysWebView
+  * StatusBar.styleDefault
+  * StatusBar.styleLightContent
+  * StatusBar.styleBlackTranslucent
+  * StatusBar.styleBlackOpaque
+  * StatusBar.backgroundColorByName
+  * StatusBar.backgroundColorByHexString
+  * StatusBar.hide
+  * StatusBar.show
+
+## Proprietà
+
+  * StatusBar.isVisible
+
+## Autorizzazioni
+
+#### config. XML
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+IOS 7, rendono la statusbar sovrapposizione o non sovrapporre WebView.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## Descrizione
+
+IOS 7, impostato su false per rendere la barra di stato vengono visualizzati come iOS 6. Impostare il colore di sfondo e stile per soddisfare utilizzando altre funzioni.
+
+## Piattaforme supportate
+
+  * iOS
+
+## Esempio rapido
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+Utilizzare la barra di stato predefinito (testo scuro, per sfondi di luce).
+
+    StatusBar.styleDefault();
+    
+
+## Piattaforme supportate
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+Utilizzare la barra di stato lightContent (testo in chiaro, per sfondi scuri).
+
+    StatusBar.styleLightContent();
+    
+
+## Piattaforme supportate
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+Utilizzare la barra di stato blackTranslucent (testo in chiaro, per sfondi scuri).
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## Piattaforme supportate
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+Utilizzare la barra di stato blackOpaque (testo in chiaro, per sfondi scuri).
+
+    StatusBar.styleBlackOpaque();
+    
+
+## Piattaforme supportate
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+IOS 7, quando StatusBar.statusBarOverlaysWebView è impostata su false, è possibile impostare il colore di sfondo della barra di stato con il nome di colore.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+Nomi di colore supportati sono:
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## Piattaforme supportate
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+Imposta il colore di sfondo della barra di stato di una stringa esadecimale.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+Proprietà di scrittura stenografica CSS sono supportati anche.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+IOS 7, quando StatusBar.statusBarOverlaysWebView è impostata su false, è possibile impostare il colore di sfondo della barra di stato di una stringa esadecimale (#RRGGBB).
+
+Su WP7 e WP8 è inoltre possibile specificare i valori come #AARRGGBB, dove AA è un valore alfa
+
+## Piattaforme supportate
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.hide
+
+Nascondere la barra di stato.
+
+    StatusBar.hide();
+    
+
+## Piattaforme supportate
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.show
+
+Mostra la barra di stato.
+
+    StatusBar.show();
+    
+
+## Piattaforme supportate
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.isVisible
+
+Leggere questa proprietà per vedere se la barra di stato è visibile o no.
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## Piattaforme supportate
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/it/index.md
+++ b/plugins/cordova-plugin-statusbar/doc/it/index.md
@@ -1,0 +1,262 @@
+<!---
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# cordova-plugin-statusbar
+
+# StatusBar
+
+> Il `StatusBar` oggetto fornisce alcune funzioni per personalizzare l'iOS e Android StatusBar.
+
+## Installazione
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## Preferenze
+
+#### config.xml
+
+*   **StatusBarOverlaysWebView** (boolean, default è true). IOS 7, rendono la statusbar sovrapposizione o la non sovrapposizione WebView all'avvio.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+*   **StatusBarBackgroundColor** (stringa esadecimale colore, predefinito è #000000). IOS 7, impostare il colore di sfondo della barra di stato di una stringa esadecimale (#RRGGBB) all'avvio.
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+*   **StatusBarStyle** (status bar in stile, default è lightcontent). IOS 7, impostare lo stile di barra di stato. Predefinita di opzioni disponibili, lightcontent, blacktranslucent, blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+## Nascondendo all'avvio
+
+In fase di esecuzione è possibile utilizzare la funzione di StatusBar.hide qui sotto, ma se si desidera che la barra di stato venga nascosta all'avvio di app, è necessario modificare il file info. plist dell'app.
+
+Aggiungere o modificare questi due attributi, se non presente. Impostare la **"barra di stato è inizialmente nascosto"** a **"YES"** e **"Aspetto di vista basati su controller status bar"** a **"NO"**. Se si modifica manualmente senza Xcode, le chiavi e i valori sono:
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## Metodi
+
+Questo plugin definisce globale oggetto `StatusBar`.
+
+Anche se in ambito globale, non è disponibile fino a dopo l'evento `deviceready`.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+*   StatusBar.overlaysWebView
+*   StatusBar.styleDefault
+*   StatusBar.styleLightContent
+*   StatusBar.styleBlackTranslucent
+*   StatusBar.styleBlackOpaque
+*   StatusBar.backgroundColorByName
+*   StatusBar.backgroundColorByHexString
+*   StatusBar.hide
+*   StatusBar.show
+
+## Proprietà
+
+*   StatusBar.isVisible
+
+## Autorizzazioni
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+IOS 7, rendono la statusbar sovrapposizione o non sovrapporre WebView.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## Descrizione
+
+IOS 7, impostato su false per rendere la barra di stato vengono visualizzati come iOS 6. Impostare il colore di sfondo e stile per soddisfare utilizzando altre funzioni.
+
+## Piattaforme supportate
+
+*   iOS
+
+## Esempio rapido
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+Utilizzare la barra di stato predefinito (testo scuro, per sfondi di luce).
+
+    StatusBar.styleDefault();
+    
+
+## Piattaforme supportate
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+Utilizzare la barra di stato lightContent (testo in chiaro, per sfondi scuri).
+
+    StatusBar.styleLightContent();
+    
+
+## Piattaforme supportate
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+Utilizzare la barra di stato blackTranslucent (testo in chiaro, per sfondi scuri).
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## Piattaforme supportate
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+Utilizzare la barra di stato blackOpaque (testo in chiaro, per sfondi scuri).
+
+    StatusBar.styleBlackOpaque();
+    
+
+## Piattaforme supportate
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+IOS 7, quando StatusBar.statusBarOverlaysWebView è impostata su false, è possibile impostare il colore di sfondo della barra di stato con il nome di colore.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+Nomi di colore supportati sono:
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## Piattaforme supportate
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+Imposta il colore di sfondo della barra di stato di una stringa esadecimale.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+Proprietà di scrittura stenografica CSS sono supportati anche.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+IOS 7, quando StatusBar.statusBarOverlaysWebView è impostata su false, è possibile impostare il colore di sfondo della barra di stato di una stringa esadecimale (#RRGGBB).
+
+Su WP7 e WP8 è inoltre possibile specificare i valori come #AARRGGBB, dove AA è un valore alfa
+
+## Piattaforme supportate
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.hide
+
+Nascondere la barra di stato.
+
+    StatusBar.hide();
+    
+
+## Piattaforme supportate
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.show
+
+Mostra la barra di stato.
+
+    StatusBar.show();
+    
+
+## Piattaforme supportate
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.isVisible
+
+Leggere questa proprietà per vedere se la barra di stato è visibile o no.
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## Piattaforme supportate
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/ja/README.md
+++ b/plugins/cordova-plugin-statusbar/doc/ja/README.md
@@ -1,0 +1,276 @@
+<!---
+# license: Licensed to the Apache Software Foundation (ASF) under one
+#         or more contributor license agreements.  See the NOTICE file
+#         distributed with this work for additional information
+#         regarding copyright ownership.  The ASF licenses this file
+#         to you under the Apache License, Version 2.0 (the
+#         "License"); you may not use this file except in compliance
+#         with the License.  You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#         Unless required by applicable law or agreed to in writing,
+#         software distributed under the License is distributed on an
+#         "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#         KIND, either express or implied.  See the License for the
+#         specific language governing permissions and limitations
+#         under the License.
+-->
+
+# cordova-plugin-statusbar
+
+[![Build Status](https://travis-ci.org/apache/cordova-plugin-statusbar.svg)](https://travis-ci.org/apache/cordova-plugin-statusbar)
+
+# StatusBar
+
+> `StatusBar`オブジェクトは、iOS と Android ステータス バーをカスタマイズするいくつかの機能を提供します。
+
+## インストール
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## 基本設定
+
+#### config.xml
+
+  * **StatusBarOverlaysWebView**(ブール値、デフォルトは true)。IOS 7、起動時にステータスバー オーバーレイまたはないオーバーレイ、WebView を作る。
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+  * **StatusBarBackgroundColor**(カラー 16 進文字列、既定値は #000000)。IOS 7 とアンドロイド 5、16 進文字列 (#RRGGBB) 起動時にステータスバーの背景色を設定します。
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+  * **StatusBarStyle**(ステータス バーのスタイル、既定値は lightcontent)。Ios 7、ステータス バーのスタイルを設定します。使用可能なオプションのデフォルト、lightcontent、blacktranslucent、blackopaque。
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+### Android の癖
+
+Android のガイドライン 5 + 指定メイン アプリよりもステータスバーの異なる色を使用して`StatusBar.backgroundColorByHexString`または`StatusBar.backgroundColorByName`経由で代わりに実行時にステータス バーの色を設定する場合がありますので (とは違って制服ステータスバー色多くの iOS 7 + アプリの) 色します。 それを行う方法の 1 つになります。
+
+```js
+if (cordova.platformId == 'android') {
+    StatusBar.backgroundColorByHexString("#333");
+}
+```
+
+## 起動時に非表示
+
+実行時に下に、StatusBar.hide 関数を使用できますが、StatusBar アプリ起動時に非表示にする場合は、アプリの Info.plist ファイルを変更する必要があります。
+
+これら 2 つの属性の追加/編集存在しない場合。 **「ステータス バーが非表示最初」** **"YES"**を設定し、 **「ビュー コント ローラー ベースのステータス バーの外観」** **"NO"**にします。 Xcode せず手動で編集する、キーと値は。
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## メソッド
+
+このプラグインでは、グローバル `StatusBar` オブジェクトを定義します。
+
+グローバル スコープではあるがそれがないまで `deviceready` イベントの後です。
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+  * StatusBar.overlaysWebView
+  * StatusBar.styleDefault
+  * StatusBar.styleLightContent
+  * StatusBar.styleBlackTranslucent
+  * StatusBar.styleBlackOpaque
+  * StatusBar.backgroundColorByName
+  * StatusBar.backgroundColorByHexString
+  * StatusBar.hide
+  * StatusBar.show
+
+## プロパティ
+
+  * StatusBar.isVisible
+
+## アクセス許可
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+IOS 7、statusbar オーバーレイまたはない WebView をオーバーレイします。
+
+    StatusBar.overlaysWebView(true);
+    
+
+## 解説
+
+IOS 7、iOS の 6 のように表示されるステータスバーを false に設定します。他の関数の使用に合わせてスタイルや背景色を設定します。
+
+## サポートされているプラットフォーム
+
+  * iOS
+
+## 簡単な例
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+既定ステータス バー (暗いテキスト、淡色の背景) を使用します。
+
+    StatusBar.styleDefault();
+    
+
+## サポートされているプラットフォーム
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+LightContent ステータスバー (暗い背景の明るいテキスト） を使用します。
+
+    StatusBar.styleLightContent();
+    
+
+## サポートされているプラットフォーム
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+BlackTranslucent ステータスバー (暗い背景の明るいテキスト） を使用します。
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## サポートされているプラットフォーム
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+BlackOpaque ステータスバー (暗い背景の明るいテキスト） を使用します。
+
+    StatusBar.styleBlackOpaque();
+    
+
+## サポートされているプラットフォーム
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+Ios 7、StatusBar.statusBarOverlaysWebView を false に設定する場合はステータスバーの背景色の色の名前によって設定できます。
+
+    StatusBar.backgroundColorByName("red");
+    
+
+サポートされている色の名前は次のとおりです。
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## サポートされているプラットフォーム
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+16 進文字列をステータス バーの背景色を設定します。
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+速記の CSS プロパティもサポートされています。
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+Ios 7、StatusBar.statusBarOverlaysWebView を false に設定する場合はステータスバーの背景色を 16 進文字列 (#RRGGBB) で設定できます。
+
+WP7 と WP8 も指定できます値 #AARRGGBB, AA は、アルファ値として
+
+## サポートされているプラットフォーム
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.hide
+
+ステータスバーを隠します。
+
+    StatusBar.hide();
+    
+
+## サポートされているプラットフォーム
+
+  * iOS
+  * アンドロイド
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.show
+
+ステータス バーが表示されます。
+
+    StatusBar.show();
+    
+
+## サポートされているプラットフォーム
+
+  * iOS
+  * アンドロイド
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.isVisible
+
+このプロパティ、ステータスバーが表示されるかどうかをお読みください。
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## サポートされているプラットフォーム
+
+  * iOS
+  * アンドロイド
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/ja/index.md
+++ b/plugins/cordova-plugin-statusbar/doc/ja/index.md
@@ -1,0 +1,262 @@
+<!---
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# cordova-plugin-statusbar
+
+# StatusBar
+
+> `StatusBar`オブジェクトは、iOS と Android ステータス バーをカスタマイズするいくつかの機能を提供します。
+
+## インストール
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## 基本設定
+
+#### config.xml
+
+*   **StatusBarOverlaysWebView**(ブール値、デフォルトは true)。IOS 7、起動時にステータスバー オーバーレイまたはないオーバーレイ、WebView を作る。
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+*   **StatusBarBackgroundColor**（色 16 進文字列、デフォルトは ＃ 000000）。Ios 7、起動時に 16 進文字列 (#RRGGBB) でステータス バーの背景色を設定します。
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+*   **StatusBarStyle**(ステータス バーのスタイル、既定値は lightcontent)。Ios 7、ステータス バーのスタイルを設定します。使用可能なオプションのデフォルト、lightcontent、blacktranslucent、blackopaque。
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+## 起動時に非表示
+
+実行時に下に、StatusBar.hide 関数を使用できますが、StatusBar アプリ起動時に非表示にする場合は、アプリの Info.plist ファイルを変更する必要があります。
+
+これら 2 つの属性の追加/編集存在しない場合。 **「ステータス バーが非表示最初」** **"YES"**を設定し、 **「ビュー コント ローラー ベースのステータス バーの外観」** **"NO"**にします。 Xcode せず手動で編集する、キーと値は。
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## メソッド
+
+このプラグインでは、グローバル `StatusBar` オブジェクトを定義します。
+
+グローバル スコープではあるがそれがないまで `deviceready` イベントの後です。
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+*   StatusBar.overlaysWebView
+*   StatusBar.styleDefault
+*   StatusBar.styleLightContent
+*   StatusBar.styleBlackTranslucent
+*   StatusBar.styleBlackOpaque
+*   StatusBar.backgroundColorByName
+*   StatusBar.backgroundColorByHexString
+*   StatusBar.hide
+*   StatusBar.show
+
+## プロパティ
+
+*   StatusBar.isVisible
+
+## アクセス許可
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+IOS 7、statusbar オーバーレイまたはない WebView をオーバーレイします。
+
+    StatusBar.overlaysWebView(true);
+    
+
+## 解説
+
+IOS 7、iOS の 6 のように表示されるステータスバーを false に設定します。他の関数の使用に合わせてスタイルや背景色を設定します。
+
+## サポートされているプラットフォーム
+
+*   iOS
+
+## 簡単な例
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+既定ステータス バー (暗いテキスト、淡色の背景) を使用します。
+
+    StatusBar.styleDefault();
+    
+
+## サポートされているプラットフォーム
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+LightContent ステータスバー (暗い背景の明るいテキスト） を使用します。
+
+    StatusBar.styleLightContent();
+    
+
+## サポートされているプラットフォーム
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+BlackTranslucent ステータスバー (暗い背景の明るいテキスト） を使用します。
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## サポートされているプラットフォーム
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+BlackOpaque ステータスバー (暗い背景の明るいテキスト） を使用します。
+
+    StatusBar.styleBlackOpaque();
+    
+
+## サポートされているプラットフォーム
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+Ios 7、StatusBar.statusBarOverlaysWebView を false に設定する場合はステータスバーの背景色の色の名前によって設定できます。
+
+    StatusBar.backgroundColorByName("red");
+    
+
+サポートされている色の名前は次のとおりです。
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## サポートされているプラットフォーム
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+16 進文字列をステータス バーの背景色を設定します。
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+速記の CSS プロパティもサポートされています。
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+Ios 7、StatusBar.statusBarOverlaysWebView を false に設定する場合はステータスバーの背景色を 16 進文字列 (#RRGGBB) で設定できます。
+
+WP7 と WP8 も指定できます値 #AARRGGBB, AA は、アルファ値として
+
+## サポートされているプラットフォーム
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.hide
+
+ステータスバーを隠します。
+
+    StatusBar.hide();
+    
+
+## サポートされているプラットフォーム
+
+*   iOS
+*   アンドロイド
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.show
+
+ステータス バーが表示されます。
+
+    StatusBar.show();
+    
+
+## サポートされているプラットフォーム
+
+*   iOS
+*   アンドロイド
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.isVisible
+
+このプロパティ、ステータスバーが表示されるかどうかをお読みください。
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## サポートされているプラットフォーム
+
+*   iOS
+*   アンドロイド
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/ko/README.md
+++ b/plugins/cordova-plugin-statusbar/doc/ko/README.md
@@ -1,0 +1,276 @@
+<!---
+# license: Licensed to the Apache Software Foundation (ASF) under one
+#         or more contributor license agreements.  See the NOTICE file
+#         distributed with this work for additional information
+#         regarding copyright ownership.  The ASF licenses this file
+#         to you under the Apache License, Version 2.0 (the
+#         "License"); you may not use this file except in compliance
+#         with the License.  You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#         Unless required by applicable law or agreed to in writing,
+#         software distributed under the License is distributed on an
+#         "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#         KIND, either express or implied.  See the License for the
+#         specific language governing permissions and limitations
+#         under the License.
+-->
+
+# cordova-plugin-statusbar
+
+[![Build Status](https://travis-ci.org/apache/cordova-plugin-statusbar.svg)](https://travis-ci.org/apache/cordova-plugin-statusbar)
+
+# StatusBar
+
+> `StatusBar`개체 iOS와 안 드 로이드 상태 표시줄을 사용자 지정 하려면 몇 가지 기능을 제공 합니다.
+
+## 설치
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## 환경 설정
+
+#### config.xml
+
+  * **StatusBarOverlaysWebView** (boolean, 기본값: true)입니다. IOS 7, 시작 시 상태 표시줄 오버레이 또는 WebView 중첩 되지 확인 합니다.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+  * **StatusBarBackgroundColor** (색상 16 진수 문자열 기본값: #000000). IOS에서 7과 안 드 로이드 5 시작 시 16 진수 문자열 (#RRGGBB) 상태 표시줄의 배경색을 설정 합니다.
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+  * **StatusBarStyle** (상태 표시줄 스타일, 기본값: lightcontent). Ios 7, 상태 표시줄 스타일을 설정 합니다. 사용 가능한 옵션 기본, lightcontent, blacktranslucent, blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+### 안 드 로이드 단점
+
+안 드 로이드 5 + 지침 보다 귀하의 주요 응용 프로그램 상태 표시줄에 대 한 다른 색을 사용 하 여 지정한 색상 (와 달리 균일 한 상태 표시줄의 색상 많은 iOS 7 + 애플 리 케이 션), `StatusBar.backgroundColorByHexString` 또는 `StatusBar.backgroundColorByName`를 통해 대신 런타임에 상태 표시줄 색을 설정 하고자 할 수 있습니다. 한 가지 방법은 일 것입니다.
+
+```js
+if (cordova.platformId == 'android') {
+    StatusBar.backgroundColorByHexString("#333");
+}
+```
+
+## 시작 시 숨기기
+
+런타임 동안 아래의 StatusBar.hide 함수를 사용할 수 있습니다 하지만 당신이 원하는 응용 프로그램 시작 시 숨겨진 상태 표시줄, 응용 프로그램의 Info.plist 파일 수정 해야 합니다.
+
+추가 편집이 두 특성이 없는 경우. **"상태 표시줄 처음 숨겨진"** **"YES"** 로 설정 하 고 **"뷰 컨트롤러 기반 상태 표시줄 모양"** **"NO"**로 설정 합니다. Xcode, 열쇠 없이 수동으로 편집 하는 경우 값은:
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## 메서드
+
+이 플러그인 글로벌 `StatusBar` 개체를 정의합니다.
+
+전역 범위에 있지만 그것은 불가능까지 `deviceready` 이벤트 후.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+  * StatusBar.overlaysWebView
+  * StatusBar.styleDefault
+  * StatusBar.styleLightContent
+  * StatusBar.styleBlackTranslucent
+  * StatusBar.styleBlackOpaque
+  * StatusBar.backgroundColorByName
+  * StatusBar.backgroundColorByHexString
+  * StatusBar.hide
+  * StatusBar.show
+
+## 속성
+
+  * StatusBar.isVisible
+
+## 사용 권한
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+IOS 7, 오버레이 또는 하지 WebView 중첩 상태 표시줄을 확인 합니다.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## 설명
+
+7 iOS, iOS 6 처럼 나타나는 상태 표시줄을 false로 설정 합니다. 다른 함수를 사용 하 여에 맞게 스타일과 배경 색상을 설정 합니다.
+
+## 지원 되는 플랫폼
+
+  * iOS
+
+## 빠른 예제
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+기본 상태 표시줄 (어두운 텍스트, 밝은 배경에 대 한)를 사용 합니다.
+
+    StatusBar.styleDefault();
+    
+
+## 지원 되는 플랫폼
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+LightContent 상태 표시줄 (어두운 배경에 대 한 가벼운 텍스트)을 사용 합니다.
+
+    StatusBar.styleLightContent();
+    
+
+## 지원 되는 플랫폼
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+BlackTranslucent 상태 표시줄 (어두운 배경에 대 한 가벼운 텍스트)을 사용 합니다.
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## 지원 되는 플랫폼
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+BlackOpaque 상태 표시줄 (어두운 배경에 대 한 가벼운 텍스트)을 사용 합니다.
+
+    StatusBar.styleBlackOpaque();
+    
+
+## 지원 되는 플랫폼
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+Ios 7, StatusBar.statusBarOverlaysWebView을 false로 설정 하면 설정할 수 있는 상태 표시줄의 배경색 색상 이름으로.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+지원 되는 색 이름입니다.
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## 지원 되는 플랫폼
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+16 진수 문자열 상태 표시줄의 배경색을 설정합니다.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+CSS 대표 속성 지원 됩니다.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+Ios 7, StatusBar.statusBarOverlaysWebView을 false로 설정 하면 설정할 수 있는 상태 표시줄의 배경색 16 진수 문자열 (#RRGGBB)에 의해.
+
+WP7 및 WP8에 당신은 또한 #AARRGGBB, AA는 알파 값으로 값을 지정할 수 있습니다.
+
+## 지원 되는 플랫폼
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.hide
+
+숨기기 상태 표시줄.
+
+    StatusBar.hide();
+    
+
+## 지원 되는 플랫폼
+
+  * iOS
+  * 안 드 로이드
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.show
+
+상태 표시줄을 표시합니다.
+
+    StatusBar.show();
+    
+
+## 지원 되는 플랫폼
+
+  * iOS
+  * 안 드 로이드
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.isVisible
+
+이 속성을 상태 표시줄 표시 되는 경우 읽기.
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## 지원 되는 플랫폼
+
+  * iOS
+  * 안 드 로이드
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/ko/index.md
+++ b/plugins/cordova-plugin-statusbar/doc/ko/index.md
@@ -1,0 +1,262 @@
+<!---
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# cordova-plugin-statusbar
+
+# StatusBar
+
+> `StatusBar`개체 iOS와 안 드 로이드 상태 표시줄을 사용자 지정 하려면 몇 가지 기능을 제공 합니다.
+
+## 설치
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## 환경 설정
+
+#### config.xml
+
+*   **StatusBarOverlaysWebView** (boolean, 기본값: true)입니다. IOS 7, 시작 시 상태 표시줄 오버레이 또는 WebView 중첩 되지 확인 합니다.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+*   **StatusBarBackgroundColor** (색상 16 진수 문자열 기본값: #000000). Ios 7, 시작 시 16 진수 문자열 (#RRGGBB) 상태 표시줄의 배경색을 설정 합니다.
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+*   **StatusBarStyle** (상태 표시줄 스타일, 기본값: lightcontent). Ios 7, 상태 표시줄 스타일을 설정 합니다. 사용 가능한 옵션 기본, lightcontent, blacktranslucent, blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+## 시작 시 숨기기
+
+런타임 동안 아래의 StatusBar.hide 함수를 사용할 수 있습니다 하지만 당신이 원하는 응용 프로그램 시작 시 숨겨진 상태 표시줄, 응용 프로그램의 Info.plist 파일 수정 해야 합니다.
+
+추가 편집이 두 특성이 없는 경우. **"상태 표시줄 처음 숨겨진"** **"YES"** 로 설정 하 고 **"뷰 컨트롤러 기반 상태 표시줄 모양"** **"NO"**로 설정 합니다. Xcode, 열쇠 없이 수동으로 편집 하는 경우 값은:
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## 메서드
+
+이 플러그인 글로벌 `StatusBar` 개체를 정의합니다.
+
+전역 범위에 있지만 그것은 불가능까지 `deviceready` 이벤트 후.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+*   StatusBar.overlaysWebView
+*   StatusBar.styleDefault
+*   StatusBar.styleLightContent
+*   StatusBar.styleBlackTranslucent
+*   StatusBar.styleBlackOpaque
+*   StatusBar.backgroundColorByName
+*   StatusBar.backgroundColorByHexString
+*   StatusBar.hide
+*   StatusBar.show
+
+## 속성
+
+*   StatusBar.isVisible
+
+## 사용 권한
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+IOS 7, 오버레이 또는 하지 WebView 중첩 상태 표시줄을 확인 합니다.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## 설명
+
+7 iOS, iOS 6 처럼 나타나는 상태 표시줄을 false로 설정 합니다. 다른 함수를 사용 하 여에 맞게 스타일과 배경 색상을 설정 합니다.
+
+## 지원 되는 플랫폼
+
+*   iOS
+
+## 빠른 예제
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+기본 상태 표시줄 (어두운 텍스트, 밝은 배경에 대 한)를 사용 합니다.
+
+    StatusBar.styleDefault();
+    
+
+## 지원 되는 플랫폼
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+LightContent 상태 표시줄 (어두운 배경에 대 한 가벼운 텍스트)을 사용 합니다.
+
+    StatusBar.styleLightContent();
+    
+
+## 지원 되는 플랫폼
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+BlackTranslucent 상태 표시줄 (어두운 배경에 대 한 가벼운 텍스트)을 사용 합니다.
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## 지원 되는 플랫폼
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+BlackOpaque 상태 표시줄 (어두운 배경에 대 한 가벼운 텍스트)을 사용 합니다.
+
+    StatusBar.styleBlackOpaque();
+    
+
+## 지원 되는 플랫폼
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+Ios 7, StatusBar.statusBarOverlaysWebView을 false로 설정 하면 설정할 수 있는 상태 표시줄의 배경색 색상 이름으로.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+지원 되는 색 이름입니다.
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## 지원 되는 플랫폼
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+16 진수 문자열 상태 표시줄의 배경색을 설정합니다.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+CSS 대표 속성 지원 됩니다.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+Ios 7, StatusBar.statusBarOverlaysWebView을 false로 설정 하면 설정할 수 있는 상태 표시줄의 배경색 16 진수 문자열 (#RRGGBB)에 의해.
+
+WP7 및 WP8에 당신은 또한 #AARRGGBB, AA는 알파 값으로 값을 지정할 수 있습니다.
+
+## 지원 되는 플랫폼
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.hide
+
+숨기기 상태 표시줄.
+
+    StatusBar.hide();
+    
+
+## 지원 되는 플랫폼
+
+*   iOS
+*   안 드 로이드
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.show
+
+상태 표시줄을 표시합니다.
+
+    StatusBar.show();
+    
+
+## 지원 되는 플랫폼
+
+*   iOS
+*   안 드 로이드
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.isVisible
+
+이 속성을 상태 표시줄 표시 되는 경우 읽기.
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## 지원 되는 플랫폼
+
+*   iOS
+*   안 드 로이드
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/pl/README.md
+++ b/plugins/cordova-plugin-statusbar/doc/pl/README.md
@@ -1,0 +1,276 @@
+<!---
+# license: Licensed to the Apache Software Foundation (ASF) under one
+#         or more contributor license agreements.  See the NOTICE file
+#         distributed with this work for additional information
+#         regarding copyright ownership.  The ASF licenses this file
+#         to you under the Apache License, Version 2.0 (the
+#         "License"); you may not use this file except in compliance
+#         with the License.  You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#         Unless required by applicable law or agreed to in writing,
+#         software distributed under the License is distributed on an
+#         "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#         KIND, either express or implied.  See the License for the
+#         specific language governing permissions and limitations
+#         under the License.
+-->
+
+# cordova-plugin-statusbar
+
+[![Build Status](https://travis-ci.org/apache/cordova-plugin-statusbar.svg)](https://travis-ci.org/apache/cordova-plugin-statusbar)
+
+# StatusBar
+
+> `StatusBar`Obiekt zawiera kilka funkcji, aby dostosować iOS i Android StatusBar.
+
+## Instalacja
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## Preferencje
+
+#### config.xml
+
+  * **StatusBarOverlaysWebView** (boolean, domyślnie na wartość true). Na iOS 7 zrobić nakładki stanu lub nie nakładki widoku sieci Web podczas uruchamiania.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+  * **StatusBarBackgroundColor** (kolor ciąg szesnastkowy, domyślnie #000000). Na iOS 7 i Android 5 kolor tła stanu przez ciąg szesnastkowy (#RRGGBB) przy starcie systemu.
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+  * **StatusBarStyle** (stan styl paska, domyślnie lightcontent.) Na iOS 7 ustawić styl paska stanu. Dostępne opcje domyślne, lightcontent, blacktranslucent, blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+### Dziwactwa Androida
+
+Android 5 + wytyczne określają przy użyciu różnych kolorów statusbar niż główne aplikacji kolor (w przeciwieństwie do stanu jednolitych kolorów wiele aplikacje iOS 7 +), więc może chcesz ustawić kolor pasek stanu w czasie wykonywania zamiast za pośrednictwem `StatusBar.backgroundColorByHexString` lub `StatusBar.backgroundColorByName`. Jednym sposobem na to byłoby:
+
+```js
+if (cordova.platformId == 'android') {
+    StatusBar.backgroundColorByHexString("#333");
+}
+```
+
+## Przy starcie
+
+Podczas uruchamiania można użyć funkcji StatusBar.hide poniżej, ale jeśli chcesz StatusBar ukryty w uruchamiania aplikacji, należy zmodyfikować plik Info.plist Twojej aplikacji.
+
+Dodawanie/edycja tych dwóch atrybutów jeśli nie obecny. Ustawianie **"pasek stanu jest początkowo ukryte"** na **"Tak"** i **"Oparte na kontroler stanu paska wygląd"** na **"Nie"**. Jeśli możesz go edytować ręcznie bez Xcode, kluczy i wartości są:
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## Metody
+
+Ten plugin definiuje obiekt globalny `StatusBar`.
+
+Chociaż w globalnym zasięgu, to nie dostępne dopiero po `deviceready` imprezie.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+  * StatusBar.overlaysWebView
+  * StatusBar.styleDefault
+  * StatusBar.styleLightContent
+  * StatusBar.styleBlackTranslucent
+  * StatusBar.styleBlackOpaque
+  * StatusBar.backgroundColorByName
+  * StatusBar.backgroundColorByHexString
+  * StatusBar.hide
+  * StatusBar.show
+
+## Właściwości
+
+  * StatusBar.isVisible
+
+## Uprawnienia
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+Na iOS 7 zrobić statusbar nakładki lub nie nakładka widoku sieci Web.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## Opis
+
+Na iOS 7 zestaw do false, aby na pasku stanu pojawia się jak iOS 6. Ustaw kolor tła i styl do korzystania z innych funkcji.
+
+## Obsługiwane platformy
+
+  * iOS
+
+## Szybki przykład
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+Użyj domyślnego stanu (ciemny tekst, teł światła).
+
+    StatusBar.styleDefault();
+    
+
+## Obsługiwane platformy
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+Użyj lightContent stanu (światło tekst, ciemne tło).
+
+    StatusBar.styleLightContent();
+    
+
+## Obsługiwane platformy
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+Użyj blackTranslucent stanu (światło tekst, ciemne tło).
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## Obsługiwane platformy
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+Użyj blackOpaque stanu (światło tekst, ciemne tło).
+
+    StatusBar.styleBlackOpaque();
+    
+
+## Obsługiwane platformy
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+Na iOS 7 gdy zostanie ustawiona wartość false, StatusBar.statusBarOverlaysWebView można ustawić kolor tła stanu przez nazwę koloru.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+Nazwy kolorów obsługiwane są:
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## Obsługiwane platformy
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+Ustawia kolor tła stanu przez ciąg szesnastkowy.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+Obsługiwane są również właściwości CSS.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+Na iOS 7 gdy zostanie ustawiona wartość false, StatusBar.statusBarOverlaysWebView można ustawić kolor tła stanu przez ciąg szesnastkowy (#RRGGBB).
+
+Na WP7 i WP8 można również określić wartości jako #AARRGGBB, gdzie AA jest wartością alfa
+
+## Obsługiwane platformy
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.hide
+
+Ukryj pasek stanu.
+
+    StatusBar.hide();
+    
+
+## Obsługiwane platformy
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.show
+
+Pokazuje pasek stanu.
+
+    StatusBar.show();
+    
+
+## Obsługiwane platformy
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.isVisible
+
+Czytać tej właściwość, aby sprawdzić, czy stanu jest widoczne lub nie.
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## Obsługiwane platformy
+
+  * iOS
+  * Android
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/pl/index.md
+++ b/plugins/cordova-plugin-statusbar/doc/pl/index.md
@@ -1,0 +1,262 @@
+<!---
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# cordova-plugin-statusbar
+
+# StatusBar
+
+> `StatusBar`Obiekt zawiera kilka funkcji, aby dostosować iOS i Android StatusBar.
+
+## Instalacja
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## Preferencje
+
+#### config.xml
+
+*   **StatusBarOverlaysWebView** (boolean, domyślnie na wartość true). Na iOS 7 zrobić nakładki stanu lub nie nakładki widoku sieci Web podczas uruchamiania.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+*   **StatusBarBackgroundColor** (kolor szesnastkowy ciąg, domyślnie #000000). Na iOS 7 ustawić kolor tła stanu przez ciąg szesnastkowy (#RRGGBB) przy starcie systemu.
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+*   **StatusBarStyle** (stan styl paska, domyślnie lightcontent.) Na iOS 7 ustawić styl paska stanu. Dostępne opcje domyślne, lightcontent, blacktranslucent, blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+## Przy starcie
+
+Podczas uruchamiania można użyć funkcji StatusBar.hide poniżej, ale jeśli chcesz StatusBar ukryty w uruchamiania aplikacji, należy zmodyfikować plik Info.plist Twojej aplikacji.
+
+Dodawanie/edycja tych dwóch atrybutów jeśli nie obecny. Ustawianie **"pasek stanu jest początkowo ukryte"** na **"Tak"** i **"Oparte na kontroler stanu paska wygląd"** na **"Nie"**. Jeśli możesz go edytować ręcznie bez Xcode, kluczy i wartości są:
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## Metody
+
+Ten plugin definiuje obiekt globalny `StatusBar`.
+
+Chociaż w globalnym zasięgu, to nie dostępne dopiero po `deviceready` imprezie.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+*   StatusBar.overlaysWebView
+*   StatusBar.styleDefault
+*   StatusBar.styleLightContent
+*   StatusBar.styleBlackTranslucent
+*   StatusBar.styleBlackOpaque
+*   StatusBar.backgroundColorByName
+*   StatusBar.backgroundColorByHexString
+*   StatusBar.hide
+*   StatusBar.show
+
+## Właściwości
+
+*   StatusBar.isVisible
+
+## Uprawnienia
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+Na iOS 7 zrobić statusbar nakładki lub nie nakładka widoku sieci Web.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## Opis
+
+Na iOS 7 zestaw do false, aby na pasku stanu pojawia się jak iOS 6. Ustaw kolor tła i styl do korzystania z innych funkcji.
+
+## Obsługiwane platformy
+
+*   iOS
+
+## Szybki przykład
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+Użyj domyślnego stanu (ciemny tekst, teł światła).
+
+    StatusBar.styleDefault();
+    
+
+## Obsługiwane platformy
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+Użyj lightContent stanu (światło tekst, ciemne tło).
+
+    StatusBar.styleLightContent();
+    
+
+## Obsługiwane platformy
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+Użyj blackTranslucent stanu (światło tekst, ciemne tło).
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## Obsługiwane platformy
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+Użyj blackOpaque stanu (światło tekst, ciemne tło).
+
+    StatusBar.styleBlackOpaque();
+    
+
+## Obsługiwane platformy
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+Na iOS 7 gdy zostanie ustawiona wartość false, StatusBar.statusBarOverlaysWebView można ustawić kolor tła stanu przez nazwę koloru.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+Nazwy kolorów obsługiwane są:
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## Obsługiwane platformy
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+Ustawia kolor tła stanu przez ciąg szesnastkowy.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+Obsługiwane są również właściwości CSS.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+Na iOS 7 gdy zostanie ustawiona wartość false, StatusBar.statusBarOverlaysWebView można ustawić kolor tła stanu przez ciąg szesnastkowy (#RRGGBB).
+
+Na WP7 i WP8 można również określić wartości jako #AARRGGBB, gdzie AA jest wartością alfa
+
+## Obsługiwane platformy
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.hide
+
+Ukryj pasek stanu.
+
+    StatusBar.hide();
+    
+
+## Obsługiwane platformy
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.show
+
+Pokazuje pasek stanu.
+
+    StatusBar.show();
+    
+
+## Obsługiwane platformy
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.isVisible
+
+Czytać tej właściwość, aby sprawdzić, czy stanu jest widoczne lub nie.
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## Obsługiwane platformy
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/ru/index.md
+++ b/plugins/cordova-plugin-statusbar/doc/ru/index.md
@@ -1,0 +1,238 @@
+<!---
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# cordova-plugin-statusbar
+
+# StatusBar
+
+> Объект `StatusBar` предоставляет некоторые функции для настройки статусной панели на iOS и Android.
+
+## Настройки
+
+#### config.xml
+
+*   **StatusBarOverlaysWebView** (логическое значение, по умолчанию true). В iOS 7 определяет необходимо ли сделать наложение статусной панели на WebView при запуске или нет.
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+*   **StatusBarBackgroundColor** (шестнадцатеричная строка цвета, значения по умолчанию #000000). На iOS 7 установит цвет фона статусной панели при запуске, на основании шестнадцатеричной строки цвета (#RRGGBB).
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+*   **StatusBarStyle** (статус бар стиль, по умолчанию lightcontent). На iOS 7 установите стиль строки состояния. Доступные параметры по умолчанию, lightcontent, blacktranslucent, blackopaque.
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+## Скрытие при запуске
+
+Во время выполнения можно использовать функцию StatusBar.hide ниже, но если вы хотите StatusBar быть скрыты при запуске приложения, необходимо изменить файл Info.plist вашего приложения.
+
+Добавьте/измените эти два атрибута, если они не присутствуют или отличаются от нижеуказанных значений. Установите значение **«Status bar is initially hidden»** равное **«YES»** и установите значение **«View controller-based status bar appearance»** на **«NO»**. Если вы измените его вручную без Xcode, ключи и значения являются следующими:
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## Методы
+
+*   StatusBar.overlaysWebView
+*   StatusBar.styleDefault
+*   StatusBar.styleLightContent
+*   StatusBar.styleBlackTranslucent
+*   StatusBar.styleBlackOpaque
+*   StatusBar.backgroundColorByName
+*   StatusBar.backgroundColorByHexString
+*   StatusBar.hide
+*   StatusBar.show
+
+## Параметры
+
+*   StatusBar.isVisible
+
+## Разрешения
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+На iOS 7 Сделайте statusbar overlay или не поверх WebView.
+
+    StatusBar.overlaysWebView(true);
+    
+
+## Описание
+
+На iOS 7 Установите значение false чтобы сделать statusbar появляются как iOS 6. Задайте стиль и цвет фона в соответствии с использованием других функций.
+
+## Поддерживаемые платформы
+
+*   iOS
+
+## Краткий пример
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+Используйте по умолчанию statusbar (темный текст, для легких стола).
+
+    StatusBar.styleDefault();
+    
+
+## Поддерживаемые платформы
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+
+# StatusBar.styleLightContent
+
+Используйте lightContent statusbar (светлый текст, на темном фоне).
+
+    StatusBar.styleLightContent();
+    
+
+## Поддерживаемые платформы
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+
+# StatusBar.styleBlackTranslucent
+
+Используйте blackTranslucent statusbar (светлый текст, на темном фоне).
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## Поддерживаемые платформы
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+
+# StatusBar.styleBlackOpaque
+
+Используйте blackOpaque statusbar (светлый текст, на темном фоне).
+
+    StatusBar.styleBlackOpaque();
+    
+
+## Поддерживаемые платформы
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+
+# StatusBar.backgroundColorByName
+
+На iOS 7 когда StatusBar.statusBarOverlaysWebView присвоено значение false, можно задать цвет фона для объекта statusbar по имени цвета.
+
+    StatusBar.backgroundColorByName("red");
+    
+
+Имена поддерживаемых цветов являются:
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## Поддерживаемые платформы
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+
+# StatusBar.backgroundColorByHexString
+
+Задает цвет фона для объекта statusbar, шестнадцатеричная строка.
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+Также поддерживаются свойства CSS стенографию.
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+На iOS 7 когда StatusBar.statusBarOverlaysWebView присвоено значение false, можно задать цвет фона для объекта statusbar, шестнадцатеричная строка (#RRGGBB).
+
+На WP7 и WP8 также можно указать значения как #AARRGGBB, где AA — это альфа-значение
+
+## Поддерживаемые платформы
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+
+# StatusBar.hide
+
+Скройте строку состояния statusbar.
+
+    StatusBar.hide();
+    
+
+## Поддерживаемые платформы
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+
+# StatusBar.show
+
+Показывает строку состояния statusbar.
+
+    StatusBar.show();
+    
+
+## Поддерживаемые платформы
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8
+
+# StatusBar.isVisible
+
+Чтение это свойство, чтобы увидеть, если statusbar является видимым или нет.
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## Поддерживаемые платформы
+
+*   iOS
+*   Android
+*   Windows Phone 7
+*   Windows Phone 8

--- a/plugins/cordova-plugin-statusbar/doc/zh/README.md
+++ b/plugins/cordova-plugin-statusbar/doc/zh/README.md
@@ -1,0 +1,276 @@
+<!---
+# license: Licensed to the Apache Software Foundation (ASF) under one
+#         or more contributor license agreements.  See the NOTICE file
+#         distributed with this work for additional information
+#         regarding copyright ownership.  The ASF licenses this file
+#         to you under the Apache License, Version 2.0 (the
+#         "License"); you may not use this file except in compliance
+#         with the License.  You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#         Unless required by applicable law or agreed to in writing,
+#         software distributed under the License is distributed on an
+#         "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#         KIND, either express or implied.  See the License for the
+#         specific language governing permissions and limitations
+#         under the License.
+-->
+
+# cordova-plugin-statusbar
+
+[![Build Status](https://travis-ci.org/apache/cordova-plugin-statusbar.svg)](https://travis-ci.org/apache/cordova-plugin-statusbar)
+
+# StatusBar
+
+> `StatusBar`物件提供了一些功能，自訂的 iOS 和 Android 狀態列。
+
+## 安裝
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## 首選項
+
+#### config.xml
+
+  * **StatusBarOverlaysWebView**（布林值，預設值為 true）。在 iOS 7，使狀態列覆蓋或不覆蓋 web 視圖在啟動時。
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+  * **StatusBarBackgroundColor**(顏色十六進位字串，預設值為 #000000)。IOS 7 和 Android 5，由十六進位字串 (#RRGGBB) 在啟動時設置狀態列的背景色。
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+  * **狀態列**（狀態列樣式，預設值為 lightcontent）。在 iOS 7，設置的狀態橫條圖樣式。可用的選項預設，lightcontent，blacktranslucent，blackopaque。
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+### Android 的怪癖
+
+Android 的 5 + 準則指定使用不同的顏色比您主要的應用程式狀態欄顏色 (不像很多 iOS 7 + 應用程式的統一狀態列顏色)，所以你可能想要設置在運行時顯示狀態列顏色而不是通過`StatusBar.backgroundColorByHexString`或`StatusBar.backgroundColorByName`。 一個的方式做到這一點將是:
+
+```js
+if (cordova.platformId == 'android') {
+    StatusBar.backgroundColorByHexString("#333");
+}
+```
+
+## 在啟動時隱藏
+
+在運行時期間，你可以使用 StatusBar.hide 函數下面，但如果你想要顯示狀態列隱藏在應用程式啟動時，你必須修改你的應用程式的 Info.plist 檔。
+
+添加編輯這兩個屬性，如果不存在。 將**"狀態列最初隱藏"**設置為**"YES"**和**"視圖基於控制器的狀態列外觀"**設置為**"否"**。 如果您手動編輯它沒有 Xcode，鍵和值是：
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## 方法
+
+這個外掛程式定義全域 `StatusBar` 物件。
+
+雖然在全球範圍內，它不可用直到 `deviceready` 事件之後。
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+  * StatusBar.overlaysWebView
+  * StatusBar.styleDefault
+  * StatusBar.styleLightContent
+  * StatusBar.styleBlackTranslucent
+  * StatusBar.styleBlackOpaque
+  * StatusBar.backgroundColorByName
+  * StatusBar.backgroundColorByHexString
+  * StatusBar.hide
+  * StatusBar.show
+
+## 屬性
+
+  * StatusBar.isVisible
+
+## 許可權
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+在 iOS 7，使狀態列覆蓋或不覆蓋 web 視圖。
+
+    StatusBar.overlaysWebView(true);
+    
+
+## 說明
+
+在 iOS 7，設置為 false，使狀態列出現像 iOS 6。設置樣式和背景顏色，適合使用其他函數。
+
+## 支援的平臺
+
+  * iOS
+
+## 快速的示例
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+使用預設狀態列 （淺色背景深色文本）。
+
+    StatusBar.styleDefault();
+    
+
+## 支援的平臺
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+使用 lightContent 狀態列 （深色背景光文本）。
+
+    StatusBar.styleLightContent();
+    
+
+## 支援的平臺
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+使用 blackTranslucent 狀態列 （深色背景光文本）。
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## 支援的平臺
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+使用 blackOpaque 狀態列 （深色背景光文本）。
+
+    StatusBar.styleBlackOpaque();
+    
+
+## 支援的平臺
+
+  * iOS
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+在 iOS 7，當您將 StatusBar.statusBarOverlaysWebView 設置為 false，你可以設置狀態列的背景色的顏色名稱。
+
+    StatusBar.backgroundColorByName("red");
+    
+
+支援的顏色名稱是：
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## 支援的平臺
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+由十六進位字串設置狀態列的背景色。
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+此外支援 CSS 速記屬性。
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+在 iOS 7，當將 StatusBar.statusBarOverlaysWebView 設置為 false，您可以設置狀態列的背景色由十六進位字串 （#RRGGBB）。
+
+WP7 和 WP8 您還可以指定值為 #AARRGGBB，其中 AA 是 Alpha 值
+
+## 支援的平臺
+
+  * iOS
+  * Android 5+
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.hide
+
+隱藏狀態列。
+
+    StatusBar.hide();
+    
+
+## 支援的平臺
+
+  * iOS
+  * Android 系統
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.show
+
+顯示狀態列。
+
+    StatusBar.show();
+    
+
+## 支援的平臺
+
+  * iOS
+  * Android 系統
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1
+
+# StatusBar.isVisible
+
+讀取此屬性，以查看狀態列是否可見。
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## 支援的平臺
+
+  * iOS
+  * Android 系統
+  * Windows Phone 7
+  * Windows Phone 8
+  * Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/doc/zh/index.md
+++ b/plugins/cordova-plugin-statusbar/doc/zh/index.md
@@ -1,0 +1,262 @@
+<!---
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# cordova-plugin-statusbar
+
+# StatusBar
+
+> `StatusBar`物件提供了一些功能，自訂的 iOS 和 Android 狀態列。
+
+## 安裝
+
+    cordova plugin add cordova-plugin-statusbar
+    
+
+## 首選項
+
+#### config.xml
+
+*   **StatusBarOverlaysWebView**（布林值，預設值為 true）。在 iOS 7，使狀態列覆蓋或不覆蓋 web 視圖在啟動時。
+    
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        
+
+*   **StatusBarBackgroundColor**（顏色十六進位字串，預設值為 #000000）。在 iOS 7，通過一個十六進位字串 （#RRGGBB） 在啟動時設置狀態列的背景色。
+    
+        <preference name="StatusBarBackgroundColor" value="#000000" />
+        
+
+*   **狀態列**（狀態列樣式，預設值為 lightcontent）。在 iOS 7，設置的狀態橫條圖樣式。可用的選項預設，lightcontent，blacktranslucent，blackopaque。
+    
+        <preference name="StatusBarStyle" value="lightcontent" />
+        
+
+## 在啟動時隱藏
+
+在運行時期間，你可以使用 StatusBar.hide 函數下面，但如果你想要顯示狀態列隱藏在應用程式啟動時，你必須修改你的應用程式的 Info.plist 檔。
+
+添加編輯這兩個屬性，如果不存在。 將**"狀態列最初隱藏"**設置為**"YES"**和**"視圖基於控制器的狀態列外觀"**設置為**"否"**。 如果您手動編輯它沒有 Xcode，鍵和值是：
+
+    <key>UIStatusBarHidden</key>
+    <true/>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+    
+
+## 方法
+
+這個外掛程式定義全域 `StatusBar` 物件。
+
+雖然在全球範圍內，它不可用直到 `deviceready` 事件之後。
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(StatusBar);
+    }
+    
+
+*   StatusBar.overlaysWebView
+*   StatusBar.styleDefault
+*   StatusBar.styleLightContent
+*   StatusBar.styleBlackTranslucent
+*   StatusBar.styleBlackOpaque
+*   StatusBar.backgroundColorByName
+*   StatusBar.backgroundColorByHexString
+*   StatusBar.hide
+*   StatusBar.show
+
+## 屬性
+
+*   StatusBar.isVisible
+
+## 許可權
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+    
+
+# StatusBar.overlaysWebView
+
+在 iOS 7，使狀態列覆蓋或不覆蓋 web 視圖。
+
+    StatusBar.overlaysWebView(true);
+    
+
+## 說明
+
+在 iOS 7，設置為 false，使狀態列出現像 iOS 6。設置樣式和背景顏色，適合使用其他函數。
+
+## 支援的平臺
+
+*   iOS
+
+## 快速的示例
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+    
+
+# StatusBar.styleDefault
+
+使用預設狀態列 （淺色背景深色文本）。
+
+    StatusBar.styleDefault();
+    
+
+## 支援的平臺
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleLightContent
+
+使用 lightContent 狀態列 （深色背景光文本）。
+
+    StatusBar.styleLightContent();
+    
+
+## 支援的平臺
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackTranslucent
+
+使用 blackTranslucent 狀態列 （深色背景光文本）。
+
+    StatusBar.styleBlackTranslucent();
+    
+
+## 支援的平臺
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.styleBlackOpaque
+
+使用 blackOpaque 狀態列 （深色背景光文本）。
+
+    StatusBar.styleBlackOpaque();
+    
+
+## 支援的平臺
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByName
+
+在 iOS 7，當您將 StatusBar.statusBarOverlaysWebView 設置為 false，你可以設置狀態列的背景色的顏色名稱。
+
+    StatusBar.backgroundColorByName("red");
+    
+
+支援的顏色名稱是：
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown
+    
+
+## 支援的平臺
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.backgroundColorByHexString
+
+由十六進位字串設置狀態列的背景色。
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+    
+
+此外支援 CSS 速記屬性。
+
+    StatusBar.backgroundColorByHexString("#333"); // => #333333
+    StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
+    
+
+在 iOS 7，當將 StatusBar.statusBarOverlaysWebView 設置為 false，您可以設置狀態列的背景色由十六進位字串 （#RRGGBB）。
+
+WP7 和 WP8 您還可以指定值為 #AARRGGBB，其中 AA 是 Alpha 值
+
+## 支援的平臺
+
+*   iOS
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.hide
+
+隱藏狀態列。
+
+    StatusBar.hide();
+    
+
+## 支援的平臺
+
+*   iOS
+*   安卓系統
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.show
+
+顯示狀態列。
+
+    StatusBar.show();
+    
+
+## 支援的平臺
+
+*   iOS
+*   安卓系統
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1
+
+# StatusBar.isVisible
+
+讀取此屬性，以查看狀態列是否可見。
+
+    if (StatusBar.isVisible) {
+        // do something
+    }
+    
+
+## 支援的平臺
+
+*   iOS
+*   安卓系統
+*   Windows Phone 7
+*   Windows Phone 8
+*   Windows Phone 8.1

--- a/plugins/cordova-plugin-statusbar/package.json
+++ b/plugins/cordova-plugin-statusbar/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "cordova-plugin-statusbar",
+  "version": "1.0.1",
+  "description": "Cordova StatusBar Plugin",
+  "cordova": {
+    "id": "cordova-plugin-statusbar",
+    "platforms": [
+      "android",
+      "ios",
+      "wp7",
+      "wp8",
+      "windows"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apache/cordova-plugin-statusbar"
+  },
+  "keywords": [
+    "cordova",
+    "statusbar",
+    "ecosystem:cordova",
+    "cordova-android",
+    "cordova-ios",
+    "cordova-wp7",
+    "cordova-wp8",
+    "cordova-windows"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.0.0"
+    }
+  ],
+  "author": "Apache Software Foundation",
+  "license": "Apache 2.0"
+}

--- a/plugins/cordova-plugin-statusbar/plugin.xml
+++ b/plugins/cordova-plugin-statusbar/plugin.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    xmlns:rim="http://www.blackberry.com/ns/widgets"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="cordova-plugin-statusbar"
+    version="1.0.1">
+    <name>StatusBar</name>
+    <description>Cordova StatusBar Plugin</description>
+    <license>Apache 2.0</license>
+    <keywords>cordova,statusbar</keywords>
+
+    <engines>
+            <engine name="cordova" version=">=3.0.0" />
+    </engines>
+
+    <js-module src="www/statusbar.js" name="statusbar">
+        <clobbers target="window.StatusBar" />
+    </js-module>
+
+    <platform name="android">
+        <source-file src="src/android/StatusBar.java" target-dir="src/org/apache/cordova/statusbar" />
+
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="StatusBar">
+                <param name="android-package" value="org.apache.cordova.statusbar.StatusBar" />
+                <param name="onload" value="true" />
+            </feature>
+        </config-file>
+    </platform>
+
+    <!-- ios -->
+    <platform name="ios">
+
+        <config-file target="config.xml" parent="/*">
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" />
+                <param name="onload" value="true" />
+            </feature>
+            <preference name="StatusBarOverlaysWebView" value="true" />
+            <preference name="StatusBarStyle" value="lightcontent" />
+        </config-file>
+
+        <header-file src="src/ios/CDVStatusBar.h" />
+        <source-file src="src/ios/CDVStatusBar.m" />
+
+    </platform>
+
+    <!-- wp7 -->
+    <platform name="wp7">
+        <config-file target="config.xml" parent="/*">
+            <feature name="StatusBar">
+                <param name="wp-package" value="StatusBar"/>
+            </feature>
+        </config-file>
+        <source-file src="src/wp/StatusBar.cs" />
+    </platform>
+
+    <!-- wp8 -->
+    <platform name="wp8">
+        <config-file target="config.xml" parent="/*">
+            <feature name="StatusBar">
+                <param name="wp-package" value="StatusBar"/>
+            </feature>
+        </config-file>
+        <source-file src="src/wp/StatusBar.cs" />
+    </platform>
+
+    <!-- windows -->
+    <platform name="windows">
+        <js-module src="src/windows/StatusBarProxy.js" name="StatusBarProxy">
+            <runs />
+        </js-module>
+    </platform>
+</plugin>

--- a/plugins/cordova-plugin-statusbar/src/android/StatusBar.java
+++ b/plugins/cordova-plugin-statusbar/src/android/StatusBar.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+package org.apache.cordova.statusbar;
+
+import android.app.Activity;
+import android.graphics.Color;
+import android.os.Build;
+import android.util.Log;
+import android.view.Window;
+import android.view.WindowManager;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaArgs;
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.PluginResult;
+import org.json.JSONException;
+
+public class StatusBar extends CordovaPlugin {
+    private static final String TAG = "StatusBar";
+
+    /**
+     * Sets the context of the Command. This can then be used to do things like
+     * get file paths associated with the Activity.
+     *
+     * @param cordova The context of the main Activity.
+     * @param webView The CordovaWebView Cordova is running in.
+     */
+    @Override
+    public void initialize(final CordovaInterface cordova, CordovaWebView webView) {
+        Log.v(TAG, "StatusBar: initialization");
+        super.initialize(cordova, webView);
+
+        this.cordova.getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                // Clear flag FLAG_FORCE_NOT_FULLSCREEN which is set initially
+                // by the Cordova.
+                Window window = cordova.getActivity().getWindow();
+                window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+
+                // Read 'StatusBarBackgroundColor' from config.xml, default is #000000.
+                setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
+            }
+        });
+    }
+
+    /**
+     * Executes the request and returns PluginResult.
+     *
+     * @param action            The action to execute.
+     * @param args              JSONArry of arguments for the plugin.
+     * @param callbackContext   The callback id used when calling back into JavaScript.
+     * @return                  True if the action was valid, false otherwise.
+     */
+    @Override
+    public boolean execute(final String action, final CordovaArgs args, final CallbackContext callbackContext) throws JSONException {
+        Log.v(TAG, "Executing action: " + action);
+        final Activity activity = this.cordova.getActivity();
+        final Window window = activity.getWindow();
+        if ("_ready".equals(action)) {
+            boolean statusBarVisible = (window.getAttributes().flags & WindowManager.LayoutParams.FLAG_FULLSCREEN) == 0;
+            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, statusBarVisible));
+        }
+
+        if ("show".equals(action)) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                }
+            });
+            return true;
+        }
+
+        if ("hide".equals(action)) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                }
+            });
+            return true;
+        }
+
+        if ("backgroundColorByHexString".equals(action)) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        setStatusBarBackgroundColor(args.getString(0));
+                    } catch (JSONException ignore) {
+                        Log.e(TAG, "Invalid hexString argument, use f.i. '#777777'");
+                    }
+                }
+            });
+            return true;
+        }
+
+        return false;
+    }
+
+    private void setStatusBarBackgroundColor(final String colorPref) {
+        if (Build.VERSION.SDK_INT >= 21) {
+            if (colorPref != null && !colorPref.isEmpty()) {
+                final Window window = cordova.getActivity().getWindow();
+                // Method and constants not available on all SDKs but we want to be able to compile this code with any SDK
+                window.clearFlags(0x04000000); // SDK 19: WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+                window.addFlags(0x80000000); // SDK 21: WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+                try {
+                    // Using reflection makes sure any 5.0+ device will work without having to compile with SDK level 21
+                    window.getClass().getDeclaredMethod("setStatusBarColor", int.class).invoke(window, Color.parseColor(colorPref));
+                } catch (IllegalArgumentException ignore) {
+                    Log.e(TAG, "Invalid hexString argument, use f.i. '#999999'");
+                } catch (Exception ignore) {
+                    // this should not happen, only in case Android removes this method in a version > 21
+                    Log.w(TAG, "Method window.setStatusBarColor not found for SDK level " + Build.VERSION.SDK_INT);
+                }
+            }
+        }
+    }
+}

--- a/plugins/cordova-plugin-statusbar/src/ios/CDVStatusBar.h
+++ b/plugins/cordova-plugin-statusbar/src/ios/CDVStatusBar.h
@@ -1,0 +1,49 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <Cordova/CDVPlugin.h>
+#import <Cordova/CDVInvokedUrlCommand.h>
+
+@interface CDVStatusBar : CDVPlugin {
+    @protected
+    BOOL _statusBarOverlaysWebView;
+    UIView* _statusBarBackgroundView;
+    BOOL _uiviewControllerBasedStatusBarAppearance;
+    UIColor* _statusBarBackgroundColor;
+    NSString* _eventsCallbackId;
+}
+
+@property (atomic, assign) BOOL statusBarOverlaysWebView;
+
+- (void) overlaysWebView:(CDVInvokedUrlCommand*)command;
+
+- (void) styleDefault:(CDVInvokedUrlCommand*)command;
+- (void) styleLightContent:(CDVInvokedUrlCommand*)command;
+- (void) styleBlackTranslucent:(CDVInvokedUrlCommand*)command;
+- (void) styleBlackOpaque:(CDVInvokedUrlCommand*)command;
+
+- (void) backgroundColorByName:(CDVInvokedUrlCommand*)command;
+- (void) backgroundColorByHexString:(CDVInvokedUrlCommand*)command;
+
+- (void) hide:(CDVInvokedUrlCommand*)command;
+- (void) show:(CDVInvokedUrlCommand*)command;
+    
+- (void) _ready:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/plugins/cordova-plugin-statusbar/src/ios/CDVStatusBar.m
+++ b/plugins/cordova-plugin-statusbar/src/ios/CDVStatusBar.m
@@ -1,0 +1,458 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+/*
+ NOTE: plugman/cordova cli should have already installed this,
+ but you need the value UIViewControllerBasedStatusBarAppearance
+ in your Info.plist as well to set the styles in iOS 7
+ */
+
+#import "CDVStatusBar.h"
+#import <objc/runtime.h>
+#import <Cordova/CDVViewController.h>
+
+static const void *kHideStatusBar = &kHideStatusBar;
+static const void *kStatusBarStyle = &kStatusBarStyle;
+
+@interface CDVViewController (StatusBar)
+
+@property (nonatomic, retain) id sb_hideStatusBar;
+@property (nonatomic, retain) id sb_statusBarStyle;
+
+@end
+
+@implementation CDVViewController (StatusBar)
+
+@dynamic sb_hideStatusBar;
+@dynamic sb_statusBarStyle;
+
+- (id)sb_hideStatusBar {
+    return objc_getAssociatedObject(self, kHideStatusBar);
+}
+
+- (void)setSb_hideStatusBar:(id)newHideStatusBar {
+    objc_setAssociatedObject(self, kHideStatusBar, newHideStatusBar, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (id)sb_statusBarStyle {
+    return objc_getAssociatedObject(self, kStatusBarStyle);
+}
+
+- (void)setSb_statusBarStyle:(id)newStatusBarStyle {
+    objc_setAssociatedObject(self, kStatusBarStyle, newStatusBarStyle, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (BOOL) prefersStatusBarHidden {
+    return [self.sb_hideStatusBar boolValue];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return (UIStatusBarStyle)[self.sb_statusBarStyle intValue];
+}
+
+@end
+
+
+@interface CDVStatusBar () <UIScrollViewDelegate>
+- (void)fireTappedEvent;
+- (void)updateIsVisible:(BOOL)visible;
+@end
+
+@implementation CDVStatusBar
+
+- (id)settingForKey:(NSString*)key
+{
+    return [self.commandDelegate.settings objectForKey:[key lowercaseString]];
+}
+
+- (void)observeValueForKeyPath:(NSString*)keyPath ofObject:(id)object change:(NSDictionary*)change context:(void*)context
+{
+    if ([keyPath isEqual:@"statusBarHidden"]) {
+        NSNumber* newValue = [change objectForKey:NSKeyValueChangeNewKey];
+        [self updateIsVisible:![newValue boolValue]];
+    }
+}
+
+- (void)pluginInitialize
+{
+    BOOL isiOS7 = (IsAtLeastiOSVersion(@"7.0"));
+
+    // init
+    NSNumber* uiviewControllerBasedStatusBarAppearance = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"];
+    _uiviewControllerBasedStatusBarAppearance = (uiviewControllerBasedStatusBarAppearance == nil || [uiviewControllerBasedStatusBarAppearance boolValue]) && isiOS7;
+
+    // observe the statusBarHidden property
+    [[UIApplication sharedApplication] addObserver:self forKeyPath:@"statusBarHidden" options:NSKeyValueObservingOptionNew context:NULL];
+
+    _statusBarOverlaysWebView = YES; // default
+
+    [self initializeStatusBarBackgroundView];
+
+    self.viewController.view.autoresizesSubviews = YES;
+
+    NSString* setting;
+
+    setting  = @"StatusBarOverlaysWebView";
+    if ([self settingForKey:setting]) {
+        self.statusBarOverlaysWebView = [(NSNumber*)[self settingForKey:setting] boolValue];
+    }
+
+    setting  = @"StatusBarBackgroundColor";
+    if ([self settingForKey:setting]) {
+        [self _backgroundColorByHexString:[self settingForKey:setting]];
+    }
+
+    setting  = @"StatusBarStyle";
+    if ([self settingForKey:setting]) {
+        [self setStatusBarStyle:[self settingForKey:setting]];
+    }
+
+    // blank scroll view to intercept status bar taps
+    self.webView.scrollView.scrollsToTop = NO;
+    UIScrollView *fakeScrollView = [[UIScrollView alloc] initWithFrame:UIScreen.mainScreen.bounds];
+    fakeScrollView.delegate = self;
+    fakeScrollView.scrollsToTop = YES;
+    [self.viewController.view addSubview:fakeScrollView]; // Add scrollview to the view heirarchy so that it will begin accepting status bar taps
+    [self.viewController.view sendSubviewToBack:fakeScrollView]; // Send it to the very back of the view heirarchy
+    fakeScrollView.contentSize = CGSizeMake(UIScreen.mainScreen.bounds.size.width, UIScreen.mainScreen.bounds.size.height * 2.0f); // Make the scroll view longer than the screen itself
+    fakeScrollView.contentOffset = CGPointMake(0.0f, UIScreen.mainScreen.bounds.size.height); // Scroll down so a tap will take scroll view back to the top
+}
+
+- (void)onReset {
+    _eventsCallbackId = nil;
+}
+
+- (void)fireTappedEvent {
+    if (_eventsCallbackId == nil) {
+        return;
+    }
+    NSDictionary* payload = @{@"type": @"tap"};
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:payload];
+    [result setKeepCallbackAsBool:YES];
+    [self.commandDelegate sendPluginResult:result callbackId:_eventsCallbackId];
+}
+
+- (void)updateIsVisible:(BOOL)visible {
+    if (_eventsCallbackId == nil) {
+        return;
+    }
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:visible];
+    [result setKeepCallbackAsBool:YES];
+    [self.commandDelegate sendPluginResult:result callbackId:_eventsCallbackId];
+}
+
+
+- (void) _ready:(CDVInvokedUrlCommand*)command
+{
+    _eventsCallbackId = command.callbackId;
+    [self updateIsVisible:![UIApplication sharedApplication].statusBarHidden];
+}
+
+- (void) initializeStatusBarBackgroundView
+{
+    CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+    statusBarFrame = [self invertFrameIfNeeded:statusBarFrame orientation:self.viewController.interfaceOrientation];
+
+    _statusBarBackgroundView = [[UIView alloc] initWithFrame:statusBarFrame];
+    _statusBarBackgroundView.backgroundColor = _statusBarBackgroundColor;
+    _statusBarBackgroundView.autoresizingMask = (UIViewAutoresizingFlexibleWidth  | UIViewAutoresizingFlexibleBottomMargin);
+    _statusBarBackgroundView.autoresizesSubviews = YES;
+}
+
+- (CGRect) invertFrameIfNeeded:(CGRect)rect orientation:(UIInterfaceOrientation)orientation {
+    // landscape is where (width > height). On iOS < 8, we need to invert since frames are
+    // always in Portrait context
+    if (UIDeviceOrientationIsLandscape(orientation) && (rect.size.width < rect.size.height) ) {
+        CGFloat temp = rect.size.width;
+        rect.size.width = rect.size.height;
+        rect.size.height = temp;
+        rect.origin = CGPointZero;
+    }
+    
+    return rect;
+}
+
+- (void) setStatusBarOverlaysWebView:(BOOL)statusBarOverlaysWebView
+{
+    // we only care about the latest iOS version or a change in setting
+    if (!IsAtLeastiOSVersion(@"7.0") || statusBarOverlaysWebView == _statusBarOverlaysWebView) {
+        return;
+    }
+
+    CGRect bounds = [[UIScreen mainScreen] bounds];
+
+    if (statusBarOverlaysWebView) {
+
+        [_statusBarBackgroundView removeFromSuperview];
+        if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+            self.webView.frame = CGRectMake(0, 0, bounds.size.height, bounds.size.width);
+        } else {
+            self.webView.frame = bounds;
+        }
+
+    } else {
+
+        CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+        statusBarFrame = [self invertFrameIfNeeded:statusBarFrame orientation:self.viewController.interfaceOrientation];
+
+        [self initializeStatusBarBackgroundView];
+
+        CGRect frame = self.webView.frame;
+        frame.origin.y = statusBarFrame.size.height;
+        frame.size.height -= statusBarFrame.size.height;
+
+        self.webView.frame = frame;
+        [self.webView.superview addSubview:_statusBarBackgroundView];
+    }
+
+    _statusBarOverlaysWebView = statusBarOverlaysWebView;
+}
+
+- (BOOL) statusBarOverlaysWebView
+{
+    return _statusBarOverlaysWebView;
+}
+
+- (void) overlaysWebView:(CDVInvokedUrlCommand*)command
+{
+    id value = [command argumentAtIndex:0];
+    if (!([value isKindOfClass:[NSNumber class]])) {
+        value = [NSNumber numberWithBool:YES];
+    }
+
+    self.statusBarOverlaysWebView = [value boolValue];
+}
+
+- (void) refreshStatusBarAppearance
+{
+    SEL sel = NSSelectorFromString(@"setNeedsStatusBarAppearanceUpdate");
+    if ([self.viewController respondsToSelector:sel]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [self.viewController performSelector:sel withObject:nil];
+#pragma clang diagnostic pop
+    }
+}
+
+- (void) setStyleForStatusBar:(UIStatusBarStyle)style
+{
+    if (_uiviewControllerBasedStatusBarAppearance) {
+        CDVViewController* vc = (CDVViewController*)self.viewController;
+        vc.sb_statusBarStyle = [NSNumber numberWithInt:style];
+        [self refreshStatusBarAppearance];
+
+    } else {
+        [[UIApplication sharedApplication] setStatusBarStyle:style];
+    }
+}
+
+- (void) setStatusBarStyle:(NSString*)statusBarStyle
+{
+    // default, lightContent, blackTranslucent, blackOpaque
+    NSString* lcStatusBarStyle = [statusBarStyle lowercaseString];
+
+    if ([lcStatusBarStyle isEqualToString:@"default"]) {
+        [self styleDefault:nil];
+    } else if ([lcStatusBarStyle isEqualToString:@"lightcontent"]) {
+        [self styleLightContent:nil];
+    } else if ([lcStatusBarStyle isEqualToString:@"blacktranslucent"]) {
+        [self styleBlackTranslucent:nil];
+    } else if ([lcStatusBarStyle isEqualToString:@"blackopaque"]) {
+        [self styleBlackOpaque:nil];
+    }
+}
+
+- (void) styleDefault:(CDVInvokedUrlCommand*)command
+{
+    [self setStyleForStatusBar:UIStatusBarStyleDefault];
+}
+
+- (void) styleLightContent:(CDVInvokedUrlCommand*)command
+{
+    [self setStyleForStatusBar:UIStatusBarStyleLightContent];
+}
+
+- (void) styleBlackTranslucent:(CDVInvokedUrlCommand*)command
+{
+    [self setStyleForStatusBar:UIStatusBarStyleBlackTranslucent];
+}
+
+- (void) styleBlackOpaque:(CDVInvokedUrlCommand*)command
+{
+    [self setStyleForStatusBar:UIStatusBarStyleBlackOpaque];
+}
+
+- (void) backgroundColorByName:(CDVInvokedUrlCommand*)command
+{
+    id value = [command argumentAtIndex:0];
+    if (!([value isKindOfClass:[NSString class]])) {
+        value = @"black";
+    }
+
+    SEL selector = NSSelectorFromString([value stringByAppendingString:@"Color"]);
+    if ([UIColor respondsToSelector:selector]) {
+        _statusBarBackgroundView.backgroundColor = [UIColor performSelector:selector];
+    }
+}
+
+- (void) _backgroundColorByHexString:(NSString*)hexString
+{
+    unsigned int rgbValue = 0;
+    NSScanner* scanner = [NSScanner scannerWithString:hexString];
+    [scanner setScanLocation:1];
+    [scanner scanHexInt:&rgbValue];
+
+    _statusBarBackgroundColor = [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
+    _statusBarBackgroundView.backgroundColor = _statusBarBackgroundColor;
+}
+
+- (void) backgroundColorByHexString:(CDVInvokedUrlCommand*)command
+{
+    NSString* value = [command argumentAtIndex:0];
+    if (!([value isKindOfClass:[NSString class]])) {
+        value = @"#000000";
+    }
+
+    if (![value hasPrefix:@"#"] || [value length] < 7) {
+        return;
+    }
+
+    [self _backgroundColorByHexString:value];
+}
+
+- (void) hideStatusBar
+{
+    if (_uiviewControllerBasedStatusBarAppearance) {
+        CDVViewController* vc = (CDVViewController*)self.viewController;
+        vc.sb_hideStatusBar = [NSNumber numberWithBool:YES];
+        [self refreshStatusBarAppearance];
+
+    } else {
+        UIApplication* app = [UIApplication sharedApplication];
+        [app setStatusBarHidden:YES];
+    }
+}
+
+- (void) hide:(CDVInvokedUrlCommand*)command
+{
+    UIApplication* app = [UIApplication sharedApplication];
+
+    if (!app.isStatusBarHidden)
+    {
+        self.viewController.wantsFullScreenLayout = YES;
+        CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+
+        [self hideStatusBar];
+
+        if (IsAtLeastiOSVersion(@"7.0")) {
+            [_statusBarBackgroundView removeFromSuperview];
+        }
+
+        if (!_statusBarOverlaysWebView) {
+
+            CGRect frame = self.webView.frame;
+            frame.origin.y = 0;
+            if (!self.statusBarOverlaysWebView) {
+                if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+                    frame.size.height += statusBarFrame.size.width;
+                } else {
+                    frame.size.height += statusBarFrame.size.height;
+                }
+            }
+
+            self.webView.frame = frame;
+        }
+
+        _statusBarBackgroundView.hidden = YES;
+    }
+}
+
+- (void) showStatusBar
+{
+    if (_uiviewControllerBasedStatusBarAppearance) {
+        CDVViewController* vc = (CDVViewController*)self.viewController;
+        vc.sb_hideStatusBar = [NSNumber numberWithBool:NO];
+        [self refreshStatusBarAppearance];
+
+    } else {
+        UIApplication* app = [UIApplication sharedApplication];
+        [app setStatusBarHidden:NO];
+    }
+}
+
+- (void) show:(CDVInvokedUrlCommand*)command
+{
+    UIApplication* app = [UIApplication sharedApplication];
+
+    if (app.isStatusBarHidden)
+    {
+        BOOL isIOS7 = (IsAtLeastiOSVersion(@"7.0"));
+        self.viewController.wantsFullScreenLayout = isIOS7;
+
+        [self showStatusBar];
+
+        if (isIOS7) {
+            CGRect frame = self.webView.frame;
+            self.viewController.view.frame = [[UIScreen mainScreen] bounds];
+
+            CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+            statusBarFrame = [self invertFrameIfNeeded:statusBarFrame orientation:self.viewController.interfaceOrientation];
+
+            if (!self.statusBarOverlaysWebView) {
+
+                // there is a possibility that when the statusbar was hidden, it was in a different orientation
+                // from the current one. Therefore we need to expand the statusBarBackgroundView as well to the
+                // statusBar's current size
+                CGRect sbBgFrame = _statusBarBackgroundView.frame;
+                frame.origin.y = statusBarFrame.size.height;
+                frame.size.height -= statusBarFrame.size.height;
+                sbBgFrame.size = statusBarFrame.size;
+
+                _statusBarBackgroundView.frame = sbBgFrame;
+                [self.webView.superview addSubview:_statusBarBackgroundView];
+            }
+
+            self.webView.frame = frame;
+
+        } else {
+
+            CGRect bounds = [[UIScreen mainScreen] applicationFrame];
+            self.viewController.view.frame = bounds;
+        }
+
+        _statusBarBackgroundView.hidden = NO;
+    }
+}
+
+- (void) dealloc
+{
+    [[UIApplication sharedApplication] removeObserver:self forKeyPath:@"statusBarHidden"];
+}
+
+
+#pragma mark - UIScrollViewDelegate
+
+- (BOOL)scrollViewShouldScrollToTop:(UIScrollView *)scrollView
+{
+    [self fireTappedEvent];
+    return NO;
+}
+
+@end

--- a/plugins/cordova-plugin-statusbar/src/windows/StatusBarProxy.js
+++ b/plugins/cordova-plugin-statusbar/src/windows/StatusBarProxy.js
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+ var _supported = null; // set to null so we can check first time
+
+ function isSupported() {
+	// if not checked before, run check
+    if (_supported == null) {
+        var viewMan = Windows.UI.ViewManagement; 
+        _supported = (viewMan.StatusBar && viewMan.StatusBar.getForCurrentView);
+    }
+    return _supported;
+ }
+
+function getViewStatusBar() {
+    if (!isSupported()) {
+        throw new Error("Status bar is not supported");
+    }
+    return Windows.UI.ViewManagement.StatusBar.getForCurrentView();
+}
+
+function hexToRgb(hex) {
+    // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
+    var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+    hex = hex.replace(shorthandRegex, function (m, r, g, b) {
+        return r + r + g + g + b + b;
+    });
+
+    var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    return result ? {
+        r: parseInt(result[1], 16),
+        g: parseInt(result[2], 16),
+        b: parseInt(result[3], 16)
+    } : null;
+}
+
+module.exports = {
+    _ready: function(win, fail) {
+        win(statusBar.occludedRect.height !== 0);
+    },
+
+    overlaysWebView: function () {
+        // not supported
+    },
+
+    styleDefault: function () {
+        // dark text ( to be used on a light background )
+        if (isSupported()) {
+            getViewStatusBar().foregroundColor = { a: 0, r: 0, g: 0, b: 0 };
+        }
+    },
+
+    styleLightContent: function () {
+        // light text ( to be used on a dark background )
+        if (isSupported()) {
+            getViewStatusBar().foregroundColor = { a: 0, r: 255, g: 255, b: 255 };
+        }
+    },
+
+    styleBlackTranslucent: function () {
+        // #88000000 ? Apple says to use lightContent instead
+        return module.exports.styleLightContent();
+    },
+
+    styleBlackOpaque: function () {
+        // #FF000000 ? Apple says to use lightContent instead
+        return module.exports.styleLightContent();
+    },
+
+    backgroundColorByHexString: function (win, fail, args) {
+        var rgb = hexToRgb(args[0]);
+        if(isSupported()) {
+            var statusBar = getViewStatusBar();
+            statusBar.backgroundColor = { a: 0, r: rgb.r, g: rgb.g, b: rgb.b };
+            statusBar.backgroundOpacity = 1;
+        }
+    },
+
+    show: function (win, fail) {
+		// added support check so no error thrown, when calling this method
+        if (isSupported()) {
+            getViewStatusBar().showAsync().done(win, fail);
+        }
+    },
+
+    hide: function (win, fail) {
+		// added support check so no error thrown, when calling this method
+        if (isSupported()) {
+            getViewStatusBar().hideAsync().done(win, fail);
+        }
+    }
+};
+require("cordova/exec/proxy").add("StatusBar", module.exports);

--- a/plugins/cordova-plugin-statusbar/src/wp/StatusBar.cs
+++ b/plugins/cordova-plugin-statusbar/src/wp/StatusBar.cs
@@ -1,0 +1,141 @@
+/*  
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+	
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+
+using Microsoft.Phone.Shell;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+
+/*
+ *   http://www.idev101.com/code/User_Interface/StatusBar.html
+ *   https://developer.apple.com/library/ios/documentation/userexperience/conceptual/transitionguide/Bars.html
+ *   https://developer.apple.com/library/ios/documentation/uikit/reference/UIApplication_Class/Reference/Reference.html#//apple_ref/c/econst/UIStatusBarStyleDefault
+ * */
+
+
+namespace WPCordovaClassLib.Cordova.Commands
+{
+    public class StatusBar : BaseCommand
+    {
+
+        // returns an argb value, if the hex is only rgb, it will be full opacity
+        protected Color ColorFromHex(string hexString)
+        {
+            string cleanHex = hexString.Replace("#", "").Replace("0x", "");
+            // turn #FFF into #FFFFFF
+            if (cleanHex.Length == 3)
+            {
+                cleanHex = "" + cleanHex[0] + cleanHex[0] + cleanHex[1] + cleanHex[1] + cleanHex[2] + cleanHex[2];
+            }
+            // add an alpha 100% if it is missing
+            if (cleanHex.Length == 6)
+            {
+                cleanHex = "FF" + cleanHex;
+            }
+            int argb = Int32.Parse(cleanHex, NumberStyles.HexNumber);
+            Color clr = Color.FromArgb((byte)((argb & 0xff000000) >> 0x18),
+                              (byte)((argb & 0xff0000) >> 0x10),
+                              (byte)((argb & 0xff00) >> 8),
+                              (byte)(argb & 0xff));
+            return clr;
+        }
+
+        public void _ready(string options)
+        {
+            Deployment.Current.Dispatcher.BeginInvoke(() =>
+            {
+                bool isVis = SystemTray.IsVisible;
+                // TODO: pass this to JS
+                //Debug.WriteLine("Result::" + res);
+                DispatchCommandResult(new PluginResult(PluginResult.Status.OK, isVis));
+            });
+        }
+
+        public void overlaysWebView(string options)
+        {    //exec(null, null, "StatusBar", "overlaysWebView", [doOverlay]);
+             // string arg = JSON.JsonHelper.Deserialize<string[]>(options)[0];
+        }
+
+        public void styleDefault(string options)
+        {    //exec(null, null, "StatusBar", "styleDefault", []);
+            Deployment.Current.Dispatcher.BeginInvoke(() =>
+            {
+                SystemTray.ForegroundColor = Colors.Black;
+            });
+        }
+
+        public void styleLightContent(string options)
+        {    //exec(null, null, "StatusBar", "styleLightContent", []);
+            
+            Deployment.Current.Dispatcher.BeginInvoke(() =>
+            {
+                SystemTray.ForegroundColor = Colors.White;
+            });
+        }
+
+        public void styleBlackTranslucent(string options)
+        {    //exec(null, null, "StatusBar", "styleBlackTranslucent", []);
+            styleLightContent(options);
+        }
+
+        public void styleBlackOpaque(string options)
+        {    //exec(null, null, "StatusBar", "styleBlackOpaque", []);
+            styleLightContent(options);
+        }
+
+        public void backgroundColorByName(string options)
+        {    //exec(null, null, "StatusBar", "backgroundColorByName", [colorname]);
+             // this should NOT be called, js should now be using/converting color names to hex 
+        }
+
+        public void backgroundColorByHexString(string options)
+        {    //exec(null, null, "StatusBar", "backgroundColorByHexString", [hexString]);
+            string argb = JSON.JsonHelper.Deserialize<string[]>(options)[0];
+
+            Color clr = ColorFromHex(argb);
+              
+            Deployment.Current.Dispatcher.BeginInvoke(() =>
+            {
+                SystemTray.Opacity = clr.A / 255.0d;
+                SystemTray.BackgroundColor = clr;
+                
+            });
+        }
+
+        public void hide(string options)
+        {    //exec(null, null, "StatusBar", "hide", []);
+            Deployment.Current.Dispatcher.BeginInvoke(() =>
+            {
+                SystemTray.IsVisible = false;
+            });
+
+        }
+
+        public void show(string options)
+        {    //exec(null, null, "StatusBar", "show", []);
+            Deployment.Current.Dispatcher.BeginInvoke(() =>
+            {
+                SystemTray.IsVisible = true;
+            });
+        }
+	}
+}

--- a/plugins/cordova-plugin-statusbar/tests/plugin.xml
+++ b/plugins/cordova-plugin-statusbar/tests/plugin.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    xmlns:rim="http://www.blackberry.com/ns/widgets"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="cordova-plugin-statusbar-tests"
+    version="1.0.1">
+    <name>Cordova StatusBar Plugin Tests</name>
+    <license>Apache 2.0</license>
+
+    <js-module src="tests.js" name="tests">
+    </js-module>
+</plugin>

--- a/plugins/cordova-plugin-statusbar/tests/tests.js
+++ b/plugins/cordova-plugin-statusbar/tests/tests.js
@@ -1,0 +1,148 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+exports.defineAutoTests = function () {
+    describe("StatusBar", function () {
+        it("statusbar.spec.1 should exist", function() {
+            expect(window.StatusBar).toBeDefined();
+        });
+
+        it("statusbar.spec.2 should have show|hide methods", function() {
+            expect(window.StatusBar.show).toBeDefined();
+            expect(typeof window.StatusBar.show).toBe("function");
+
+            expect(window.StatusBar.hide).toBeDefined();
+            expect(typeof window.StatusBar.hide).toBe("function");
+        });
+
+        it("statusbar.spec.3 should have set backgroundColor methods", function() {
+            expect(window.StatusBar.backgroundColorByName).toBeDefined();
+            expect(typeof window.StatusBar.backgroundColorByName).toBe("function");
+
+            expect(window.StatusBar.backgroundColorByHexString).toBeDefined();
+            expect(typeof window.StatusBar.backgroundColorByHexString).toBe("function");
+        });
+
+        it("statusbar.spec.4 should have set style methods", function() {
+            expect(window.StatusBar.styleBlackTranslucent).toBeDefined();
+            expect(typeof window.StatusBar.styleBlackTranslucent).toBe("function");
+
+            expect(window.StatusBar.styleDefault).toBeDefined();
+            expect(typeof window.StatusBar.styleDefault).toBe("function");
+
+            expect(window.StatusBar.styleLightContent).toBeDefined();
+            expect(typeof window.StatusBar.styleLightContent).toBe("function");
+
+            expect(window.StatusBar.styleBlackOpaque).toBeDefined();
+            expect(typeof window.StatusBar.styleBlackOpaque).toBe("function");
+
+            expect(window.StatusBar.overlaysWebView).toBeDefined();
+            expect(typeof window.StatusBar.overlaysWebView).toBe("function");
+        });
+    });
+};
+
+exports.defineManualTests = function (contentEl, createActionButton) {
+    function log(msg) {
+        var el = document.getElementById("info");
+        var logLine = document.createElement('div');
+        logLine.innerHTML = msg;
+        el.appendChild(logLine);
+    }
+
+    function doShow() {
+        StatusBar.show();
+        log('StatusBar.isVisible=' + StatusBar.isVisible);
+    }
+
+    function doHide() {
+        StatusBar.hide();
+        log('StatusBar.isVisible=' + StatusBar.isVisible);
+    }
+
+    function doColor1() {
+        log('set color=red');
+        StatusBar.backgroundColorByName('red');
+    }
+
+    function doColor2() {
+        log('set style=translucent black');
+        StatusBar.styleBlackTranslucent();
+    }
+
+    function doColor3() {
+        log('set style=default');
+        StatusBar.styleDefault();
+    }
+
+    var showOverlay = true;
+    function doOverlay() {
+        showOverlay = !showOverlay;
+        StatusBar.overlaysWebView(showOverlay);
+        log('Set overlay=' + showOverlay);
+    }
+
+    /******************************************************************************/
+
+    contentEl.innerHTML = '<div id="info"></div>' +
+        'Also: tapping bar on iOS should emit a log.' +
+        '<div id="action-show"></div>' +
+        'Expected result: Status bar will be visible' +
+        '</p> <div id="action-hide"></div>' +
+        'Expected result: Status bar will be hidden' +
+        '</p> <div id="action-color2"></div>' +
+        'Expected result: Status bar text will be a light (white) color' +
+        '</p> <div id="action-color3"></div>' +
+        'Expected result: Status bar text will be a dark (black) color' +
+        '</p> <div id="action-overlays"></div>' +
+        'Expected result:<br>Overlay true = status bar will lay on top of web view content<br>Overlay false = status bar will be separate from web view and will not cover content' +
+        '</p> <div id="action-color1"></div>' +
+        'Expected result: If overlay false, background color for status bar will be red';
+
+    log('StatusBar.isVisible=' + StatusBar.isVisible);
+    window.addEventListener('statusTap', function () {
+        log('tap!');
+    }, false);
+
+    createActionButton("Show", function () {
+        doShow();
+    }, 'action-show');
+
+    createActionButton("Hide", function () {
+        doHide();
+    }, 'action-hide');
+
+    createActionButton("Style=red (background)", function () {
+        doColor1();
+    }, 'action-color1');
+
+    createActionButton("Style=translucent black", function () {
+        doColor2();
+    }, 'action-color2');
+
+    createActionButton("Style=default", function () {
+        doColor3();
+    }, 'action-color3');
+
+    createActionButton("Toggle Overlays", function () {
+        doOverlay();
+    }, 'action-overlays');
+};

--- a/plugins/cordova-plugin-statusbar/www/statusbar.js
+++ b/plugins/cordova-plugin-statusbar/www/statusbar.js
@@ -1,0 +1,109 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var exec = require('cordova/exec');
+
+var namedColors = {
+    "black": "#000000",
+    "darkGray": "#A9A9A9",
+    "lightGray": "#D3D3D3",
+    "white": "#FFFFFF",
+    "gray": "#808080",
+    "red": "#FF0000",
+    "green": "#00FF00",
+    "blue": "#0000FF",
+    "cyan": "#00FFFF",
+    "yellow": "#FFFF00",
+    "magenta": "#FF00FF",
+    "orange": "#FFA500",
+    "purple": "#800080",
+    "brown": "#A52A2A"
+};
+
+var StatusBar = {
+
+    isVisible: true,
+
+    overlaysWebView: function (doOverlay) {
+        exec(null, null, "StatusBar", "overlaysWebView", [doOverlay]);
+    },
+
+    styleDefault: function () {
+        // dark text ( to be used on a light background )
+        exec(null, null, "StatusBar", "styleDefault", []);
+    },
+
+    styleLightContent: function () {
+        // light text ( to be used on a dark background )
+        exec(null, null, "StatusBar", "styleLightContent", []);
+    },
+
+    styleBlackTranslucent: function () {
+        // #88000000 ? Apple says to use lightContent instead
+        exec(null, null, "StatusBar", "styleBlackTranslucent", []);
+    },
+
+    styleBlackOpaque: function () {
+        // #FF000000 ? Apple says to use lightContent instead
+        exec(null, null, "StatusBar", "styleBlackOpaque", []);
+    },
+
+    backgroundColorByName: function (colorname) {
+        return StatusBar.backgroundColorByHexString(namedColors[colorname]);
+    },
+
+    backgroundColorByHexString: function (hexString) {
+        if (hexString.charAt(0) !== "#") {
+            hexString = "#" + hexString;
+        }
+
+        if (hexString.length === 4) {
+            var split = hexString.split("");
+            hexString = "#" + split[1] + split[1] + split[2] + split[2] + split[3] + split[3];
+        }
+
+        exec(null, null, "StatusBar", "backgroundColorByHexString", [hexString]);
+    },
+
+    hide: function () {
+        exec(null, null, "StatusBar", "hide", []);
+        StatusBar.isVisible = false;
+    },
+
+    show: function () {
+        exec(null, null, "StatusBar", "show", []);
+        StatusBar.isVisible = true;
+    }
+
+};
+
+// prime it
+exec(function (res) {
+    if (typeof res == 'object') {
+        if (res.type == 'tap') {
+            cordova.fireWindowEvent('statusTap');
+        }
+    } else {
+        StatusBar.isVisible = res;
+    }
+}, null, "StatusBar", "_ready", []);
+
+module.exports = StatusBar;

--- a/plugins/fetch.json
+++ b/plugins/fetch.json
@@ -15,5 +15,13 @@
         },
         "is_top_level": true,
         "variables": {}
+    },
+    "cordova-plugin-statusbar": {
+        "source": {
+            "type": "registry",
+            "id": "cordova-plugin-statusbar"
+        },
+        "is_top_level": true,
+        "variables": {}
     }
 }

--- a/plugins/ios.json
+++ b/plugins/ios.json
@@ -25,6 +25,18 @@
                         {
                             "xml": "<feature name=\"Geolocation\"><param name=\"ios-package\" value=\"CDVLocation\" /></feature>",
                             "count": 1
+                        },
+                        {
+                            "xml": "<feature name=\"StatusBar\"><param name=\"ios-package\" value=\"CDVStatusBar\" /><param name=\"onload\" value=\"true\" /></feature>",
+                            "count": 1
+                        },
+                        {
+                            "xml": "<preference name=\"StatusBarOverlaysWebView\" value=\"true\" />",
+                            "count": 1
+                        },
+                        {
+                            "xml": "<preference name=\"StatusBarStyle\" value=\"lightcontent\" />",
+                            "count": 1
                         }
                     ]
                 }
@@ -46,6 +58,9 @@
             "PACKAGE_NAME": "com.azavea.pwd-waterworks-revealed"
         },
         "cordova-plugin-geolocation": {
+            "PACKAGE_NAME": "com.azavea.pwd-waterworks-revealed"
+        },
+        "cordova-plugin-statusbar": {
             "PACKAGE_NAME": "com.azavea.pwd-waterworks-revealed"
         }
     },

--- a/src/config.xml
+++ b/src/config.xml
@@ -25,15 +25,24 @@
     <preference name="phonegap-version"           value="3.7.0" />          <!-- all: current version of PhoneGap -->
     <preference name="orientation"                value="default" />        <!-- all: default means both landscape and portrait are enabled -->
     <preference name="target-device"              value="universal" />      <!-- all: possible values handset, tablet, or universal -->
-    <preference name="fullscreen"                 value="true" />           <!-- all: hides the status bar at the top of the screen -->
+    <preference name="fullscreen"                 value="false" />           <!-- all: hides the status bar at the top of the screen -->
     <preference name="prerendered-icon"           value="true" />           <!-- ios: if icon is prerendered, iOS will not apply it's gloss to the app's icon on the user's home screen -->
-    <preference name="ios-statusbarstyle"         value="black-opaque" />   <!-- ios: black-translucent will appear black because the PhoneGap webview doesn't go beneath the status bar -->
     <preference name="detect-data-types"          value="false" />          <!-- ios: controls whether data types (such as phone no. and dates) are automatically turned into links by the system -->
     <preference name="exit-on-suspend"            value="false" />          <!-- ios: if set to true, app will terminate when home button is pressed -->
     <preference name="auto-hide-splash-screen"    value="true" />           <!-- ios: if set to false, the splash screen must be hidden using a JavaScript API -->
     <preference name="android-minSdkVersion"      value="10" />              <!-- android: MIN SDK version supported on the target device. MAX version is blank by default. -->
     <preference name="android-installLocation"    value="auto" />           <!-- android: app install location. 'auto' will choose. 'internalOnly' is device memory. 'preferExternal' is SDCard. -->
     <preference name="BackupWebStorage"           value="none"/>
+
+    <platform name="ios">
+        <preference name="StatusBarOverlaysWebView"   value="false" />
+        <preference name="StatusBarBackgroundColor"   value="#000000" />
+        <preference name="StatusBarStyle"             value="lightcontent" />
+    </platform>
+
+    <platform name="android">
+        <preference name="StatusBarBackgroundColor"   value="#000000" />
+    </platform>
 
     <!-- Core plugins -->
     <gap:plugin name="org.apache.cordova.camera" version="0.2.9" />


### PR DESCRIPTION
In iOS it seems we cannot totally hide the top status bar. Added the cordova
status bar plugin to allow us to prevent our data from overlapping the status
bar. Removed fullscreen mode so we have app consistency and show the status bar
on android as well. In both cases make the status bar black. Remove what
appeared to be legacy status bar config from config.xml.

Connects #120

To test:

 * Build for android and iOS.
 * Note black status bar at top of screen.