### PR TITLE
Feature/lol/new card instructions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,20 +50,22 @@ module.exports = function(grunt) {
         cssVendorPath    = distDir + 'vendor.css',
         cssMinBundlePath = distDir + 'bundle.min.css',
         zipFilePath = tempDir + 'app.zip',
-        appAssets = [
+        watchAssets = [
             'config.xml',
             'index.html',
-            'quests/**/*',
             'sass/lib/leaflet.css',
             'sass/lib/fontello.css',
             'sass/lib/bootstrap.min.css',
             'sass/lib/bootstrap-dialog.min.css',
             'sass/font/*',
             'sass/fonts/*',
-            'tiles/**/*',
             'img/**/*',
             'quests.json'
-        ];
+        ],
+        appAssets = watchAssets.concat([
+            'quests/**/*',
+            'tiles/**/*'
+        ]);
 
     grunt.initConfig({
         jshint: {
@@ -160,7 +162,7 @@ module.exports = function(grunt) {
                 tasks: ['quests', 'copy']
             },
             assets: {
-                files: appAssets,
+                files: watchAssets,
                 tasks: ['copy:app']
             }
         }

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Prototype app to guide users on "quests" which reveal interesting things about t
 
 This application is build using PhoneGap/Cordova which allows for a native application on Android and iOS to be build using HTML/CSS/JS. Here's how to set everything up to use it for Water Works Revealed.
 
-##### Clone the repo
+#### Clone the repo
 ```shell
 git clone git@github.com:azavea/pwd-waterworks-revealed
 ```
 
-##### Set up grunt
+#### Set up grunt
 ```shell
 npm install -g grunt-cli phonegap
 npm install
@@ -20,12 +20,16 @@ grunt
 ```
 You may need to run the first install command as a super user (sudo).
 
-##### Try a build cycle
+#### Try a build cycle
 Modify `src/index.html`, and then build:
 ```shell
 grunt
 ```
-##### Using the PhoneGap Developer App
+
+#### Local Testing
+The application is designed and intended to by run on a touch device. You can run the built site in a standard browser (Firefox and Chrome have been tested thoroughly) with the caveat that you must be running in mobile emulation mode (supported in the aforementioned browsers' developer tools) to ensure touch events are properly triggered.
+
+#### Using the PhoneGap Developer App
 
 If you want to more quickly view changes to the app during development, you can skip the publish and build process by using the PhoneGap Developer App. Instructions to install the app on your machine and development device can be found at [http://app.phonegap.com/](http://app.phonegap.com/) and are reproduced here:
 
@@ -37,7 +41,7 @@ If you want to more quickly view changes to the app during development, you can 
 
 Once you are connected to the application on the device, run `grunt watch` locally. The app will reload on the device anytime grunt catches a change.
 
-##### Update Map Tiles
+#### Update Map Tiles
 
 Map tiles were generated in MapBox Studio (https://www.mapbox.com/mapbox-studio/).
 To alter them you will need a running copy of mapbox studio. The current project was created by Daniel (https://github.com/dmcglone/mapbox-studio-pencil.tm2).

--- a/src/index.html
+++ b/src/index.html
@@ -178,7 +178,7 @@
                 </div>
                 <div class="page-content scrollable toggle-modern">
                   <div>
-                    <label for="enable-mock-location" >Enable Mock Locations:</label>
+                    <label>Enable Mock Locations:</label>
                     <div id="enable-mock-location">
                         <input type="radio" name="mock-location" value="false" checked>Off
                         <input type="radio" name="mock-location" value="true">On

--- a/src/js/cards.js
+++ b/src/js/cards.js
@@ -85,21 +85,28 @@ function setUpAudio() {
         $audioButton = $audioPlayer.find('.audio-control'),
         $audioEl = $('#card-holder').find('audio'),
         sound = $audioEl.get(0),
-        playingClass = 'playing';
+        playingClass = 'playing',
+        playMessage = 'Play Audio',
+        pauseMessage = 'Pause Audio',
+        replayMessage = 'Play Again';
 
-    // Reset on sound completion.
+    // Update UI on audio events.
     $audioEl.on('ended', function() {
-        $audioButton.removeClass(playingClass).text('Play Again');
+        $audioButton.removeClass(playingClass).text(replayMessage);
+    });
+    $audioEl.on('playing', function() {
+        $audioButton.addClass(playingClass).text(pauseMessage);
+    });
+    $audioEl.on('pause', function() {
+        $audioButton.removeClass(playingClass).text(playMessage);
     });
 
     // Single button audio player.
     $audioButton.on('click', function() {
         if ($(this).hasClass(playingClass)) {
             sound.pause();
-            $(this).removeClass(playingClass).text('Play Audio');
         } else {
             sound.play();
-            $(this).addClass(playingClass).text('Pause Audio');
         }
     });
 
@@ -190,11 +197,20 @@ function swipeNavigateCards(e) {
                 // Remove the alignment message in the header as we move away.
                 $target.find('.card-header .alignment-message').fadeOut(200);
 
-                // Attempt to start the audio if it exists.
+                // Attempt to start the audio if it exists and the
+                // circumstances are correct.
                 try {
-                    $target.find('audio').get(0).play();
+                    // Only play unplayed audio. Determine this by looking at
+                    // the current time and the duration of the audio clip. If
+                    // they are both zero or undefined, then it is safe to
+                    // assume that the audio has never been played.
+                    var sound = $target.find('audio').get(0);
+
+                    if (!sound.currentTime && !sound.duration) {
+                        sound.play();
+                    }
                 } catch (exc) {
-                    // Expecting: TypeError "Cannot read property 'play' of undefined"
+                    // Expecting: TypeError "Cannot read property ... of undefined"
                     if (exc.name !== 'TypeError') {
                         throw exc;
                     }

--- a/src/js/cards.js
+++ b/src/js/cards.js
@@ -38,11 +38,7 @@ function openZoneDeck(zone, activeQuest) {
             secondaryPath: directory + '/secondary/',
             mediaPath: directory + '/media/',
             zone: zone,
-            showIntroCard: showIntroCard,
-            audioCacheBuster: (function(){
-                var d = new Date();
-                return d.getTime();
-            })() // self executing function to get a unix timestamp.
+            showIntroCard: showIntroCard
         };
 
     context.audioPlayer = audioPlayerTemplate(context);

--- a/src/js/cards.js
+++ b/src/js/cards.js
@@ -8,7 +8,8 @@ var $ = require('./jqueryBacon').$,
     zoneTemplate = require('../templates/zone.ejs'),
     audioPlayerTemplate = require('../templates/audioPlayer.ejs');
 
-var deckFinishedBus = new Bacon.Bus();
+var deckFinishedBus = new Bacon.Bus(),
+    showIntroCard = true;
 
 function init() {
     var cardHolder = $('#card-holder');
@@ -34,10 +35,10 @@ function openZoneDeck(zone, activeQuest) {
             secondaryPath: directory + '/secondary/',
             mediaPath: directory + '/media/',
             zone: zone,
+            showIntroCard: showIntroCard
         };
 
     context.audioPlayer = audioPlayerTemplate(context);
-
     var html = zoneTemplate(context);
     addDeckToPage(html);
 
@@ -55,6 +56,25 @@ function addDeckToPage(html) {
 
         // Now that our card holder has a deck in it prepare audio.
         setUpAudio();
+
+        handleIntroCard();
+}
+
+function handleIntroCard() {
+    if (showIntroCard) {
+        var $introCard = $('#card-holder').find('.card.introcard');
+        $introCard.find('button.introbutton').on('click', function() {
+            $introCard.fadeOut(200, function() {
+                $introCard.remove();
+            });
+
+            // We only want to show the intro instruction card on the first
+            // zone opened. After that set to false and never show it again.
+            // But the user must first click the button to surpress the
+            // popup again.
+            showIntroCard = false;
+        });
+    }
 }
 
 function setUpAudio() {
@@ -116,6 +136,11 @@ function finishZone(e) {
 }
 
 function swipeNavigateCards(e) {
+    if (showIntroCard) {
+        // If the intro card is still visible, disable swipe events.
+        return;
+    }
+
     var $target = $(e.currentTarget),
         type = e.type,
         $thisCard = $target.find('.card.active'),
@@ -162,9 +187,7 @@ function swipeNavigateCards(e) {
                 .prev()
                 .addClass('active')
                 .removeClass('prev');
-        } else {
-            closeDeck($thisCard);
-        }
+        } // If no more cards before this one, do nothing.
     }
 }
 

--- a/src/js/cards.js
+++ b/src/js/cards.js
@@ -24,6 +24,9 @@ function init() {
     // Allow swipe events to move through the card stack.
     cardHolder.on('swipeRight', swipeNavigateCards);
     cardHolder.on('swipeLeft', swipeNavigateCards);
+    cardHolder.on('click', '.nextslide', function() {
+        cardHolder.trigger('swipeLeft');
+    });
     cardHolder.on('click', '.poster', handleVideoTap);
 }
 
@@ -137,7 +140,7 @@ function finishZone(e) {
 
 function swipeNavigateCards(e) {
     if (showIntroCard) {
-        // If the intro card is still visible, disable swipe events.
+        // If the intro card is still visible, cancel out of swipe events.
         return;
     }
 
@@ -161,12 +164,6 @@ function swipeNavigateCards(e) {
     // Proxy the swipe events to the next and back/close buttons since they have
     // all the logic wired up already.
     if (type === 'swipeLeft') {
-        // Don't allow users to swipe away the
-        // last card in the deck.
-        if ($thisCard.hasClass('last')) {
-            return;
-        }
-
         // If there is another card in the stack, move to it.
         if ($thisCard.next().hasClass('card')) {
             $thisCard
@@ -175,10 +172,12 @@ function swipeNavigateCards(e) {
                 .next()
                 .addClass('active')
                 .removeClass('next');
-        } else {
-            // No next card so close the deck.
-            closeDeck($thisCard);
-        }
+
+            if ($thisCard.hasClass('first')) {
+                // Remove the alignment message in the header as we move away.
+                $target.find('.card-header .alignment-message').fadeOut(200);
+            }
+        } // No more cards? We are on the exit card, which has a close button.
     } else if (type === 'swipeRight') {
         if ($thisCard.prev().hasClass('card')){
             $thisCard
@@ -187,6 +186,11 @@ function swipeNavigateCards(e) {
                 .prev()
                 .addClass('active')
                 .removeClass('prev');
+
+            if ($thisCard.prev().hasClass('first')) {
+                // Remove the alignment message in the header as we move away.
+                $target.find('.card-header .alignment-message').fadeIn(200);
+            }
         } // If no more cards before this one, do nothing.
     }
 }

--- a/src/js/geolocator.js
+++ b/src/js/geolocator.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var Bacon = require('baconjs');
 

--- a/src/js/jqueryBacon.js
+++ b/src/js/jqueryBacon.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var Bacon = require('baconjs'),
     $ = require('jquery');

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -145,7 +145,9 @@ function changeZoneStyle(showDeck, zone) {
 
         // Once a zone has been entered, a user can click on the marker
         // to launch the card deck instead of having to revisit the zone.
-        addZoneClickEvent(zone, showDeck);
+        if (!zone.clickStream) {
+            addZoneClickEvent(zone, showDeck);
+        }
     } else {
         zone.layer.setStyle(zoneStyle.unstarted);
         removeZoneClickEvent(zone);

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var L = require('leaflet'),
     $ = require('jquery'),

--- a/src/js/questManager.js
+++ b/src/js/questManager.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var _ = require('lodash'),
     $ = require('jquery'),

--- a/src/js/questManager.js
+++ b/src/js/questManager.js
@@ -120,10 +120,6 @@ function closeBootstrapDialog(dialog) {
     dialog.close();
 }
 
-function switchToZone(zone) {
-    cards.openZoneDeck(zone, ACTIVE_QUEST);
-}
-
 function showDeck(zone) {
     cards.openZoneDeck(zone, ACTIVE_QUEST);
 }

--- a/src/js/shim/jquery.js
+++ b/src/js/shim/jquery.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 // Make jQuery an alias of Zepto for use in bootsrap etc.
 var jQuery = require('zepto');

--- a/src/js/zoneStyles.js
+++ b/src/js/zoneStyles.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 module.exports = {
     inactive: {

--- a/src/sass/modules/_cards.scss
+++ b/src/sass/modules/_cards.scss
@@ -18,6 +18,17 @@
             right: 0;
             background-color: black;
             z-index: 5500;
+
+            .alignment-message {
+                position: absolute;
+                z-index: 100;
+                width: 100%;
+                background-color: black;
+                padding: 15px 10px;
+                font-size: 20px;
+                color: white;
+                font-weight: bold;
+            }
         }
 
         .card-header {
@@ -43,6 +54,18 @@
                 text-align: right;
                 font-size: 30px;
                 padding: 5px 10px;
+            }
+
+            .alignment-message {
+                width: 100%;
+                height: calc(100% + 2px);
+                position: absolute;
+                background-color: black;
+                color: white;
+                padding: 15px 10px;
+                font-size: 20px;
+                top:0;
+                left:0;
             }
         }
 
@@ -70,39 +93,6 @@
                 background-color: rgba(255, 255, 255, 0.8);
             }
 
-            > .card-header {
-                height: 44px;
-                padding: 10px;
-                position: absolute;
-                width: 100%;
-                top: 0;
-                z-index: 9;
-
-                a {
-                    padding: 2px;
-                    color: white;
-                    cursor: pointer;
-
-                    &.left {
-                        float: left;
-                    }
-                    &.right {
-                        float: right;
-                    }
-                    &[data-navigate="close"] {
-                        font-size: 3.6rem;
-                        padding: 0px 8px;
-                        font-weight: 700;
-                        line-height: 1;
-                    }
-
-                    > span.glyphicon {
-                        font-size: 2.1rem;
-                        line-height: 1.4;
-                        padding: 0 2px;
-                    }
-                }
-            }
             > .card-visual {
                 height: 100%;
                 width: 100%;

--- a/src/sass/modules/_cards.scss
+++ b/src/sass/modules/_cards.scss
@@ -8,6 +8,18 @@
         background: #000;
         box-shadow: 0 0 15px rgba(0,0,0,0.75);
 
+        .card.introcard {
+            height: 100%;
+            width: 100%;
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background-color: black;
+            z-index: 5500;
+        }
+
         .card-header {
             position: absolute;
             z-index: 100;
@@ -47,6 +59,15 @@
                         color: $wr-blue;
                     }
                 }
+            }
+
+            .instructions {
+                width: 100%;
+                bottom: 0px;
+                position: absolute;
+                overflow: auto;
+                padding: 20px;
+                background-color: rgba(255, 255, 255, 0.8);
             }
 
             > .card-header {

--- a/src/templates/audioPlayer.ejs
+++ b/src/templates/audioPlayer.ejs
@@ -1,8 +1,8 @@
 <% if (zone.audio) { %>
     <span class="audio-control playing">Pause Audio</span>
-    <audio autoplay>
+    <audio preload="none">
         <% _.each(zone.audio.files, function(file) { %>
-            <source src="<%= mediaPath %><%= file.file %>" type="<%= file.type %>" />
+            <source src="<%= mediaPath %><%= file.file %>?c=<%= audioCacheBuster %>" type="<%= file.type %>" />
         <% }); %>
     </audio>
 <% } %>

--- a/src/templates/audioPlayer.ejs
+++ b/src/templates/audioPlayer.ejs
@@ -2,7 +2,7 @@
     <span class="audio-control playing">Pause Audio</span>
     <audio preload="none">
         <% _.each(zone.audio.files, function(file) { %>
-            <source src="<%= mediaPath %><%= file.file %>?c=<%= audioCacheBuster %>" type="<%= file.type %>" />
+            <source src="<%= mediaPath %><%= file.file %>" type="<%= file.type %>" />
         <% }); %>
     </audio>
 <% } %>

--- a/src/templates/zone.ejs
+++ b/src/templates/zone.ejs
@@ -2,7 +2,7 @@
     <div class="cards">
         <% if (showIntroCard) { %>
             <div class="card introcard">
-                <div class="card-header">Align your device!</div>
+                <div class="alignment-message">Align your device!</div>
                 <!-- TODO: Add BG image here -->
                 <div class="card-visual fullsize" style="background-image: url();"></div>
                 <div class="card-content footer">
@@ -12,10 +12,11 @@
             </div>
         <% } %>
         <div class="card-header">
+            <div class="alignment-message">Align your device!</div>
             <span class="close-deck">&times;</span>
             <%= audioPlayer %>
         </div>
-        <div class="card card-fullimage">
+        <div class="card card-fullimage first">
             <div class="card-visual fullsize" style="background-image: url('<%= primaryPath %><%= zone.primaryItems[0].name %>.jpg');">
             </div>
             <!-- Remove captions at request of client. Keep the structure around in case we want to add them back -->
@@ -26,7 +27,7 @@
             </div>
             -->
             <div class="instructions">
-                Swipe left to continue
+                <button class="nextslide">Next</button>
             </div>
         </div>
         <div class="card next">

--- a/src/templates/zone.ejs
+++ b/src/templates/zone.ejs
@@ -1,5 +1,16 @@
 <div class="overlay" data-zone="<%= zone.id %>" style="display:none">
     <div class="cards">
+        <% if (showIntroCard) { %>
+            <div class="card introcard">
+                <div class="card-header">Align your device!</div>
+                <!-- TODO: Add BG image here -->
+                <div class="card-visual fullsize" style="background-image: url();"></div>
+                <div class="card-content footer">
+                    <p>When you enter a quest, you will be asked to align the photo on your device with the environment around you.</p>
+                    <button class="introbutton">Get Started</button>
+                </div>
+            </div>
+        <% } %>
         <div class="card-header">
             <span class="close-deck">&times;</span>
             <%= audioPlayer %>
@@ -7,9 +18,15 @@
         <div class="card card-fullimage">
             <div class="card-visual fullsize" style="background-image: url('<%= primaryPath %><%= zone.primaryItems[0].name %>.jpg');">
             </div>
+            <!-- Remove captions at request of client. Keep the structure around in case we want to add them back -->
+            <!--
             <div class="card-content slider">
                 <%- zone.primaryItems[0].caption %>
                 <strong><%- zone.primaryItems[0].credit %></strong>
+            </div>
+            -->
+            <div class="instructions">
+                Swipe left to continue
             </div>
         </div>
         <div class="card next">
@@ -32,9 +49,15 @@
             <% } else { %>
                 <div class="card-visual" style="background-image: url('<%= primaryPath %><%= zone.primaryItems[1].name %>.jpg');">
                 </div>
+                <!-- Remove captions at request of client. Keep the structure around in case we want to add them back -->
+                <!--
                 <div class="card-content slider">
                     <%- zone.primaryItems[1].caption %>
                     <strong><%- zone.primaryItems[1].credit %></strong>
+                </div>
+                -->
+                <div class="instructions">
+                    Swipe left to continue
                 </div>
             <% } %>
         </div>
@@ -42,9 +65,15 @@
             <div class="card next">
                 <div class="card-visual" style="background-image: url('<%= secondaryPath %><%= item.name %>.jpg');"></div>
                 <div class="card-icon"></div>
+                <!-- Remove captions at request of client. Keep the structure around in case we want to add them back -->
+                <!--
                 <div class="card-content slider">
                     <%- item.caption %>
                     <strong><%- item.credit %></strong>
+                </div>
+                -->
+                <div class="instructions">
+                    Swipe left to continue
                 </div>
             </div>
         <% }); %>


### PR DESCRIPTION
Connects #123 

Reworks the interface to match new designs show in #123. Images and better styling are missing and will be supplied by @jfrankl. 
 * Creates a global instruction screen that shows up as first card of first zone entered and never again.
 * Creates an alignment message and different instructions on first card of zone.
 * Starts audio playing only when swiping to second card in zone.

To test:
 * build and run
 * Start app. Enter zone.
 * Regardless of which zone is entered you should see the global instruction page.
 * Subsequent loads of the zone or different zones should not show the instruction page.
 * Loading the audio zone (southmost zone on east side) should play audio only after moving to second card in zone (not counting intro card if you visit here first).
 * Leaving and re-entering the zone should continue to play audio.
 * Paused audio should not start playing again if you move back to the initial alignment screen and then forward. Auto play should only occur one time on each load of a zone and this should happen when moving from the first card (alignment card) to second card.