### PR TITLE
Feature/lol/adjust card transitions

### DIFF
--- a/src/js/cards.js
+++ b/src/js/cards.js
@@ -251,6 +251,10 @@ function handleVideoTap(e) {
         $poster.show();
         $video.hide();
     });
+
+    $video.on('click', function() {
+        $video.get(0).pause();
+    });
 }
 
 function toggleCardContent(e) {

--- a/src/js/cards.js
+++ b/src/js/cards.js
@@ -194,8 +194,12 @@ function swipeNavigateCards(e) {
                 .removeClass('next');
 
             if ($thisCard.hasClass('first')) {
-                // Remove the alignment message in the header as we move away.
+                // As we move away, remove the alignment message in the header,
+                // fade the first card out and bring up the global swipe
+                // instructions.
                 $target.find('.card-header .alignment-message').fadeOut(200);
+                $target.find('.instructions-default').fadeIn(600);
+                $thisCard.fadeOut(600);
 
                 // Attempt to start the audio if it exists and the
                 // circumstances are correct.
@@ -227,8 +231,12 @@ function swipeNavigateCards(e) {
                 .removeClass('prev');
 
             if ($thisCard.prev().hasClass('first')) {
-                // Remove the alignment message in the header as we move away.
+                // As we transition to the first card, bring back the alignment
+                // message in the header, fade the first card in and hide the
+                // global swipe instructions.
                 $target.find('.card-header .alignment-message').fadeIn(200);
+                $target.find('.instructions-default').fadeOut(600);
+                $thisCard.prev().fadeIn(600);
             }
         } // If no more cards before this one, do nothing.
     }

--- a/src/sass/modules/_cards.scss
+++ b/src/sass/modules/_cards.scss
@@ -73,6 +73,16 @@
             }
         }
 
+        .instructions {
+            width: 100%;
+            bottom: 0px;
+            position: absolute;
+            overflow: auto;
+            padding: 20px;
+            z-index: 12;
+            background-color: rgba(255, 255, 255, 0.8);
+        }
+
         .card {
             @include card();
 
@@ -94,6 +104,7 @@
                 position: absolute;
                 overflow: auto;
                 padding: 20px;
+                z-index: 13;
                 background-color: rgba(255, 255, 255, 0.8);
             }
 
@@ -300,6 +311,9 @@
     &.prev {
         z-index: 9;
     }
+    &.first {
+        z-index: 13;
+    }
     &.active {
         -webkit-transform: translate3d(0,0,0);
         transform: translate3d(0,0,0);
@@ -309,9 +323,21 @@
         -webkit-transform: translate3d(125%,0,0);
         transform: translate3d(125%,0,0);
     }
+    &.next.second {
+        -webkit-transform: translate3d(0,0,0);
+        transform: translate3d(0,0,0);
+    }
     &.prev {
         -webkit-transform: translate3d(-125%,0,0);
         transform: translate3d(-125%,0,0);
+    }
+    &.prev.first {
+        -webkit-transform: translate3d(0,0,0);
+        transform: translate3d(0,0,0);
+        z-index: 13;
+    }
+    &.active.first {
+        z-index: 13;
     }
 }
 

--- a/src/templates/zone.ejs
+++ b/src/templates/zone.ejs
@@ -63,6 +63,11 @@
             <span class="close-deck">&times;</span>
             <%= audioPlayer %>
         </div>
+
+        <div class="instructions text-center instructions-default">
+            <img class="icon-swipe" src="img/icon_swipe-left.png">Swipe left to continue
+        </div>
+
         <div class="card card-fullimage first">
             <div class="card-visual fullsize" style="background-image: url('<%= primaryPath %><%= zone.primaryItems[0].name %>.jpg');">
             </div>
@@ -73,12 +78,12 @@
                 <strong><%- zone.primaryItems[0].credit %></strong>
             </div>
             -->
-            <div class="instructions text-center">
+            <div class="instructions text-center instructions-first">
                 <p>Align the photo on your device with the environment around you.</p>
                 <button class="nextslide btn enterarea-button btn-primary btn-lg btn-large enter ">Okay, it's aligned!</button>
             </div>
         </div>
-        <div class="card next">
+        <div class="card next second">
             <% if (zone.primaryItems[1].type && zone.primaryItems[1].type === 'video') { %>
                 <div class="card-visual">
                     <div class="flex">
@@ -104,9 +109,6 @@
                     <strong><%- zone.primaryItems[1].credit %></strong>
                 </div>
                 -->
-                <div class="instructions text-center">
-                    <img class="icon-swipe" src="img/icon_swipe-left.png">Swipe left to continue
-                </div>
             <% } %>
         </div>
         <% _.each(zone.secondaryItems, function(item) { %>
@@ -120,9 +122,6 @@
                     <strong><%- item.credit %></strong>
                 </div>
                 -->
-                <div class="instructions text-center">
-                    <img class="icon-swipe" src="img/icon_swipe-left.png">Swipe left to continue
-                </div>
             </div>
         <% }); %>
         <div class="card next last">

--- a/src/templates/zone.ejs
+++ b/src/templates/zone.ejs
@@ -3,9 +3,7 @@
         <% if (showIntroCard) { %>
             <div class="card introcard">
                 <div class="alignment-message">Align your device!</div>
-                <!-- TODO: Add BG image here -->
-                <div class="card-visual alignment-background fullsize" style="background-image: url();">
-
+                <div class="card-visual alignment-background fullsize">
                     <svg class="align-animation-container" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 366.7 290" preserveAspectRatio="">
                         <g class="align-animation-scene">
                             <polygon fill="#008983" points="102.7,44 181.3,6.6 259.9,44     "/>
@@ -53,7 +51,6 @@
                             </g>
                         </g>
                     </svg>
-
                 </div>
                 <div class="card-content text-center footer">
                     <p>When you enter a quest, you will be asked to align the photo on your device with the environment around you.</p>

--- a/src/templates/zone.ejs
+++ b/src/templates/zone.ejs
@@ -82,10 +82,9 @@
             <% if (zone.primaryItems[1].type && zone.primaryItems[1].type === 'video') { %>
                 <div class="card-visual">
                     <div class="flex">
-                        <video controls
-                                style="width:100%;"
-                                src="<%= mediaPath %><%= zone.primaryItems[1].name %>"
-                                poster="<%= mediaPath %><%= zone.primaryItems[1].poster %>">
+                        <video style="width:100%;"
+                               poster="<%= mediaPath %><%= zone.primaryItems[1].poster %>">
+                            <source src="<%= mediaPath %><%= zone.primaryItems[1].name %>" type="video/mp4" />
                         </video>
                         <div class="poster">
                             <div class="poster-inner">


### PR DESCRIPTION
Adjusts handing and transition behaviour for cards.

Connects #130 

To test:
 * Build and run
 * Move to a new zone
 * Note that when transitioning between the first card and second, the first should fade out.
 * Transitioning from second to first should fade in the first card.
 * When swiping between cards, the "swipe left" message should persist on the bottom.