### PR TITLE
Show small zone confirmation screen for finished zones.

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -182,8 +182,14 @@ function bindConfirmationButtonEvents($dialog, questManager, zone) {
         });
 }
 
-function activateZoneConfirmation() {
-    $('#enterarea').removeClass('enterarea-dismissed').addClass('active');
+function activateZoneConfirmation(zone) {
+    if (zone.status === zoneUtils.STATUS_FINISHED) {
+        // If the zone has already been completed, only show the small
+        // zone confirmation window.
+        $('#enterarea').addClass('enterarea-dismissed active');
+    } else {
+        $('#enterarea').removeClass('enterarea-dismissed').addClass('active');
+    }
 }
 
 function dismissZoneConfirmation() {

--- a/src/templates/zone.ejs
+++ b/src/templates/zone.ejs
@@ -144,7 +144,7 @@
             <div class="card-icon"></div>
             <div class="card-message">
                 You just finished the <%= zone.title %> zone. Congrats!
-                <div id="finish-zone"><i class="icon-moon"></i> Exit</div>
+                <div id="finish-zone">Exit</div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
* If a zone has been completed, only show the small version
of the confirmation screen when reentering the zone.

**Testing instructions:**
- Using the Chrome location emulation tool, enter a zone (A good starting location is 39.966304, -75.183411).
- The full zone confirmation pane should open.
- Complete the zone.
- Leave the zone and reenter it.
- The small zone confirmation pane should open. 

Connects to #145 