### PR TITLE
Apply targeted scaling to intro text.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -40,11 +40,13 @@
             <div class="modaloverlay-container">
                 <div id="introduction-modaloverlay" class="modaloverlay">
                     <div class="modaloverlay-content">
-                        <p>Welcome to the Fairmount Water Works' "Urban Water Revealed Prototype app." This work in progress is meant to give Philadelphians and visitors to our city self-guided access to the grounds of the historic Water Works complex through space and time.</p>
-                        <p>Please traverse our landscape to discover viewing points as portals that will take you through time to better understand the 19th century landmark innovation before you and its continued significance in the global water story.</p>
-                        <p>Enjoy!</p>
-                        <p>Karen Young &mdash; Executive Director, The Fairmount Water Works</p>
-                        <div id="button-close-introduction" class="modaloverlay-button">Get Started</div>
+                        <div id="intro-content">
+                            <p>Welcome to the Fairmount Water Works' "Urban Water Revealed Prototype app." This work in progress is meant to give Philadelphians and visitors to our city self-guided access to the grounds of the historic Water Works complex through space and time.</p>
+                            <p>Please traverse our landscape to discover viewing points as portals that will take you through time to better understand the 19th century landmark innovation before you and its continued significance in the global water story.</p>
+                            <p>Enjoy!</p>
+                            <p>Karen Young &mdash; Executive Director, The Fairmount Water Works</p>
+                            <div id="button-close-introduction" class="modaloverlay-button">Get Started</div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/js/cards.js
+++ b/src/js/cards.js
@@ -4,6 +4,7 @@ var $ = require('./jqueryBacon').$,
     _ = require('lodash'),
     path = require('path'),
     Bacon = require('baconjs'),
+    utils = require('./utils'),
     zoneUtils = require('./zoneUtils'),
     zoneTemplate = require('../templates/zone.ejs'),
     audioPlayerTemplate = require('../templates/audioPlayer.ejs');
@@ -42,12 +43,24 @@ function openZoneDeck(zone, activeQuest) {
         };
 
     context.audioPlayer = audioPlayerTemplate(context);
+
     var html = zoneTemplate(context);
     addDeckToPage(html);
 
-    adjustHistoricContentFontSize();
+    var $contextEl = $('#card-holder').find('.historic-context'),
+        $container = $contextEl.parent(),
+        options = {
+            allowUpscale: true,
+            subElement: 'p',
+            offset: 50
+        };
+    // Make the font size of the historic context screen large enough to fill the
+    // appropriate space. This helps make the text look good on various devices.
+    utils.adjustFontSizeToEl($contextEl, $container, options);
     $(window).on('orientationchange', function() {
-        setTimeout(adjustHistoricContentFontSize, 1000);
+        setTimeout(function() {
+            utils.adjustFontSizeToEl($contextEl, $container, options);
+        }, 1000);
     });
 
     $('#finish-zone').on('click', finishZone);
@@ -302,29 +315,6 @@ function toggleCardContent(e) {
             }, animationSpeed);
         }
     });
-}
-
-/**
- * Make the font size of the historic context screen large enough to fill the
- * appropriate space. This helps make the text look good on various devices.
- */
-function adjustHistoricContentFontSize() {
-    var $contextEl = $('#card-holder').find('.historic-context'),
-        $contextText = $contextEl.find('p'),
-        parentHeight = $contextEl.parent().height() - 50, // 50px accounts for the bottom bar.
-        fontSize = 12,
-        increment = 1;
-
-    do {
-        $contextText.css('font-size', fontSize + 'px');
-        fontSize += increment;
-    } while(parentHeight > $contextEl.height());
-
-    // We might have gone over. If so back off one notch.
-    if (parentHeight < $contextEl.height()) {
-        fontSize -= increment;
-        $contextText.css('font-size', fontSize + 'px');
-    }
 }
 
 module.exports = {

--- a/src/js/intro.js
+++ b/src/js/intro.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var $ = require('jquery');
+var $ = require('jquery'),
+    utils = require('./utils');
 
 var $introduction = $('#introduction'),
     $circle = $('#overlay-circle');
@@ -11,6 +12,13 @@ module.exports = {
         $introduction.on('click', animateOpenCircle);
 
         $('#button-close-introduction').on('click', animateSwitchMap);
+
+        var opts = {
+            subElement: 'p',
+            offset: 120,
+            allowUpscale: false
+        };
+        utils.adjustFontSizeToEl($('#intro-content'), $introduction, opts);
 
         // TODO: Switch to bootstrap's $.support.transition.end; see http://stackoverflow.com/a/13862291
         $introduction.on('transitionend webkitTransitionEnd oTransitionEnd otransitionend MSTransitionEnd', function(e) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var $ = require('jquery').$;
+
+/**
+ * Make font large enough to fill the appropriate space but ensure that it does
+ * not get too large. This helps make the text look good on various devices.
+ * 
+ * @param $target - A jQuery selection of the element for which the text should
+ * be resized.
+ * 
+ * @param $container - A jQuery selection of the container in which the target
+ * should be constrained 
+ * 
+ * @param options - dictionary of options
+ * offset: int - buffer size in px.
+ * allowUpscale: boolean - allow the font size to exceed the size specified in the CSS. 
+ * subElement: string - apply scaling only to elements matching this selection within $target.
+ */
+function adjustFontSizeToEl($target, $container, options) {
+    options = options || {};
+    options.offset = options.offset || 0;
+    options.allowUpscale = options.allowUpscale || false;
+    options.subElement = options.subElement || null;
+
+    var $contextText;
+
+    if (options.subElement !== null) {
+        $contextText = $target.find(options.subElement);
+    } else {
+        $contextText = $target;
+    }
+
+    var parentHeight = $container.height() - options.offset,
+        fontSize = 12,
+        increment = 1,
+        maxFontSize = options.allowUpscale ? Infinity : Number($contextText.css('font-size').replace('px', ''));
+
+    do {
+        $contextText.css('font-size', fontSize + 'px');
+        fontSize += increment;
+    } while(parentHeight > $target.height() && fontSize <= maxFontSize);
+
+    // We might have gone over. If so back off one notch.
+    if (parentHeight < $target.height()) {
+        fontSize -= increment;
+        $contextText.css('font-size', fontSize + 'px');
+    }
+}
+
+module.exports = {
+    adjustFontSizeToEl: adjustFontSizeToEl
+};


### PR DESCRIPTION
We want to ensure that the intro text does not get too large and that
users can move on to the next screen even on smaller devices. Extract
the text scaling function used previously on the historic context text
of cards and make it generically useful to any text and container.

Connects #151 

To test:
 * Use chrome dev tools or a smaller iPhone.
 * Check that all the intro text remains readable on the screen and that the "get started" button is visible and easily clickable.
 * Check the historic context text (last card in a deck) to ensure the text scaling still works.
 * Check on larger device or simulator. Ensure things still look good. 