### PR TITLE
Always hide zone confirmation at start of zone.

### DIFF
--- a/src/js/questManager.js
+++ b/src/js/questManager.js
@@ -4,9 +4,11 @@ var _ = require('lodash'),
     $ = require('jquery'),
     Bacon = require('baconjs'),
     BootstrapDialog = require('bootstrap-dialog'),
+    path = require('path'),
     cards = require('./cards'),
     zoneUtils = require('./zoneUtils'),
-    quests = require('../quests.json');
+    quests = require('../quests.json'),
+    zoneConfirmationTemplate = require('../templates/zoneConfirmation.ejs');
 
 var ACTIVE_QUEST = 'fairmount-water-works',
     DEFAULT_PRIMARY_CAPTION = 'Align your screen so that it matches up with the view you see here, tap to show/hide captions.',
@@ -26,6 +28,7 @@ module.exports = {
                 .doAction(onZoneFinished);
 
         initStatus();
+        initZoneConfirmation(zoneChangeStream);
 
         zones.forEach(function(z) {
             var firstPhoto = _.first(z.primaryItems);
@@ -121,5 +124,77 @@ function closeBootstrapDialog(dialog) {
 }
 
 function showDeck(zone) {
+    hideZoneConfirmation();
     cards.openZoneDeck(zone, ACTIVE_QUEST);
+}
+
+function initZoneConfirmation(zoneChangeStream) {
+    zoneChangeStream
+        .doAction(hideZoneConfirmation)
+        .filter(_.isObject)
+        .doAction(updateDialog)
+        .onValue(activateZoneConfirmation);
+}
+
+function updateDialog(zone) {
+    var $dialog = $('#enterarea'),
+        context = {
+            zone: zone,
+            mediaPath: getConfirmationMediaPath(zone)
+        };
+
+    $dialog.html(zoneConfirmationTemplate(context));
+
+    bindConfirmationButtonEvents($dialog, zone);
+}
+
+function getConfirmationMediaPath(zone) {
+    var basePath = path.join('quests', ACTIVE_QUEST, zone.id),
+        mediaPath;
+
+    if (zone.primaryItems[1].type && zone.primaryItems[1].type === 'video') {
+        mediaPath = path.join(basePath, 'media', zone.primaryItems[1].poster);
+    } else {
+        mediaPath = path.join(basePath, 'primary', zone.primaryItems[1].name + '.jpg');
+    }
+
+    return mediaPath;
+}
+
+function bindConfirmationButtonEvents($dialog, zone) {
+    $dialog
+        .find('.enterarea-button.enter')
+        .click(function() {
+            showDeck(zone);
+        });
+
+    $dialog
+        .find('.enterarea-button.dismiss')
+        .click(function() {
+            dismissZoneConfirmation();
+        });
+}
+
+function activateZoneConfirmation(zone) {
+    if (zone.status === zoneUtils.STATUS_FINISHED) {
+        // If the zone has already been completed, only show the small
+        // zone confirmation window.
+        $('#enterarea').addClass('enterarea-dismissed active');
+    } else {
+        $('#enterarea').removeClass('enterarea-dismissed').addClass('active');
+    }
+}
+
+function dismissZoneConfirmation() {
+    $('#enterarea').addClass('enterarea-dismissed');
+}
+
+function hideZoneConfirmation() {
+    var $dialog = $('#enterarea');
+
+    if ($dialog.hasClass('enterarea-dismissed')) {
+        $dialog.removeClass('active');
+    } else {
+        $dialog.removeClass('active enterarea-dismissed');
+    }
 }

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -3,11 +3,9 @@
 var $ = require('jquery'),
     _ = require('lodash'),
     Snap = require('Snap'),
-    path = require('path'),
     pageManager = require('./pages'),
     progressTemplate = require('../templates/progress.ejs'),
-    zoneUtils = require('./zoneUtils'),
-    zoneConfirmationTemplate = require('../templates/zoneConfirmation.ejs');
+    zoneUtils = require('./zoneUtils');
 
 var snap,
     questManager;
@@ -25,7 +23,6 @@ function init(options) {
     initSnap();
     initQuestProgress(questManager);
     initCompass();
-    initZoneConfirmation(questManager);
 
     $('.menu-link').on('click', toggleMenu);
     $('.menu').on('click', 'a', togglePages);
@@ -133,82 +130,6 @@ function togglePages(e) {
     } else {
         toggleMenu();
     }
-}
-
-function initZoneConfirmation(questManager) {
-    questManager.zoneChangeStream
-        .doAction(hideZoneConfirmation)
-        .filter(_.isObject)
-        .doAction(updateDialog, questManager)
-        .onValue(activateZoneConfirmation);
-}
-
-function updateDialog(questManager, zone) {
-    var $dialog = $('#enterarea'),
-        context = {
-            zone: zone,
-            mediaPath: getConfirmationMediaPath(questManager, zone)
-        };
-
-    $dialog.html(zoneConfirmationTemplate(context));
-
-    bindConfirmationButtonEvents($dialog, questManager, zone);
-}
-
-function getConfirmationMediaPath(questManager, zone) {
-    var basePath = path.join('quests', questManager.activeQuest, zone.id),
-        mediaPath;
-
-    if (zone.primaryItems[1].type && zone.primaryItems[1].type === 'video') {
-        mediaPath = path.join(basePath, 'media', zone.primaryItems[1].poster);
-    } else {
-        mediaPath = path.join(basePath, 'primary', zone.primaryItems[1].name + '.jpg');
-    }
-
-    return mediaPath;
-}
-
-function bindConfirmationButtonEvents($dialog, questManager, zone) {
-    $dialog
-        .find('.enterarea-button.enter')
-        .click(function() {
-            startZone(questManager, zone);
-        });
-
-    $dialog
-        .find('.enterarea-button.dismiss')
-        .click(function() {
-            dismissZoneConfirmation();
-        });
-}
-
-function activateZoneConfirmation(zone) {
-    if (zone.status === zoneUtils.STATUS_FINISHED) {
-        // If the zone has already been completed, only show the small
-        // zone confirmation window.
-        $('#enterarea').addClass('enterarea-dismissed active');
-    } else {
-        $('#enterarea').removeClass('enterarea-dismissed').addClass('active');
-    }
-}
-
-function dismissZoneConfirmation() {
-    $('#enterarea').addClass('enterarea-dismissed');
-}
-
-function hideZoneConfirmation() {
-    var $dialog = $('#enterarea');
-
-    if ($dialog.hasClass('enterarea-dismissed')) {
-        $dialog.removeClass('active');
-    } else {
-        $dialog.removeClass('active enterarea-dismissed');
-    }
-}
-
-function startZone(questManager, zone) {
-    hideZoneConfirmation();
-    questManager.showDeck(zone);
 }
 
 module.exports = {


### PR DESCRIPTION
* Move zone confirmation logic to questManager module and hide zone
confirmation when zone deck is shown. This was the simplest solution to
ensuring that anytime the showDeck method (walking into a zone, clicking
on a completed zone, and clicking on a zone in the "My Quests" list) is
called, the zone confirmation is hidden.

**Testing instructions:**
- Enter a zone.
- The zone confirmation screen should appear.
- Click "Dismiss". The zone confirmation screen should minimize.
- Leave the zone. The zone confirmation screen should animate out.
- Enter and complete a zone.
- Leave the zone and enter a new zone, but do not click "Enter".
- Open the "My Quests" page.
- Click the zone you first completed.
- That zone should start and the zone confirmation screen from the previous zone should be gone.
- Complete or exit the zone.
- Enter a new zone.
- The zone confirmation screen should appear.

Connects to #142, #153