### PR TITLE
Adjust intro screen text formatting.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -41,9 +41,10 @@
                 <div id="introduction-modaloverlay" class="modaloverlay">
                     <div class="modaloverlay-content">
                         <div id="intro-content">
-                            <p>Welcome to the Fairmount Water Works' "Urban Water Revealed Prototype app." This work in progress is meant to give Philadelphians and visitors to our city self-guided access to the grounds of the historic Water Works complex through space and time.</p>
+                            <h4>Welcome to the Fairmount Water Works' "Urban Water Revealed Prototype app."</h4>
+                            <p>This work in progress is meant to give Philadelphians and visitors to our city self-guided access to the grounds of the historic Water Works complex through space and time.</p>
                             <p>Please traverse our landscape to discover viewing points as portals that will take you through time to better understand the 19th century landmark innovation before you and its continued significance in the global water story.</p>
-                            <p>Enjoy!</p>
+                            <p><em>Enjoy!</em></p>
                             <p>Karen Young &mdash; Executive Director, The Fairmount Water Works</p>
                             <div id="button-close-introduction" class="modaloverlay-button">Get Started</div>
                         </div>

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -34,10 +34,12 @@ function adjustFontSizeToEl($target, $container, options) {
     var parentHeight = $container.height() - options.offset,
         fontSize = 12,
         increment = 1,
+        lineHeightMultiplier = 1.5, // Set line height to be 1.5 times the font-size, a commonly recommended guideline
         maxFontSize = options.allowUpscale ? Infinity : Number($contextText.css('font-size').replace('px', ''));
 
     do {
         $contextText.css('font-size', fontSize + 'px');
+        $contextText.css('line-height', (fontSize * lineHeightMultiplier) + 'px');
         fontSize += increment;
     } while(parentHeight > $target.height() && fontSize <= maxFontSize);
 
@@ -45,6 +47,7 @@ function adjustFontSizeToEl($target, $container, options) {
     if (parentHeight < $target.height()) {
         fontSize -= increment;
         $contextText.css('font-size', fontSize + 'px');
+        $contextText.css('line-height', (fontSize * lineHeightMultiplier) + 'px');
     }
 }
 


### PR DESCRIPTION
* Give the intro text some hierarchy by putting the title in
a header element and the sign-off in a em element.
* Adjust the line-height as a function of font size to give
the text better spacing.

Before:

![screen shot 2015-09-21 at 9 40 14 am](https://cloud.githubusercontent.com/assets/1042475/9993292/fd26b96e-6044-11e5-84ac-7319cce0ba95.png)

After:

![screen shot 2015-09-21 at 9 39 47 am](https://cloud.githubusercontent.com/assets/1042475/9993295/0039c77c-6045-11e5-8c58-dd71bfe6c5c7.png)


**Testing instructions:**
- Using the chrome device emulator, or actual devices, test that the intro text is always readable and the app start button in never hidden.

Connects to #148