### PR TITLE
Enable photo captions & attributions

### DIFF
--- a/src/js/cards.js
+++ b/src/js/cards.js
@@ -289,6 +289,13 @@ function prepareVideoHandling(cardHolder) {
 }
 
 function toggleCardContent(e) {
+    // Don't toggle captions on taps received by the first card in a slideshow
+    // and the first a/v media card in a slideshow beginning with a video.
+    if ($('.second.next').length ||
+        $('.next.second').length ||
+        $('.second.active .card-visual .flex').length) {
+        return;
+    }
     // Not the most beautiful but a workable solution. If the tap came from a
     // video, ignore it and move on.
     if (e.target.tagName === 'VIDEO') { return; }
@@ -305,7 +312,7 @@ function toggleCardContent(e) {
         if ($caption.hasClass('caption-hidden')) {
             $caption.removeClass('caption-hidden');
             $caption.animate({
-                bottom: '0'
+                bottom: '60px'
             }, animationSpeed);
         } else {
             var offset = $caption.height() * -1;

--- a/src/sass/modules/_cards.scss
+++ b/src/sass/modules/_cards.scss
@@ -219,7 +219,7 @@
                     bottom: 56px;
                 }
                 width: 100%;
-                bottom: 0px;
+                bottom: 60px;
                 position: absolute;
                 overflow: auto;
                 padding: 20px;

--- a/src/templates/zone.ejs
+++ b/src/templates/zone.ejs
@@ -63,7 +63,6 @@
             <span class="close-deck">&times;</span>
             <%= audioPlayer %>
         </div>
-
         <div class="instructions text-center instructions-default">
             <img class="icon-swipe" src="img/icon_swipe-left.png">Swipe left to continue
         </div>
@@ -71,13 +70,6 @@
         <div class="card card-fullimage first">
             <div class="card-visual fullsize" style="background-image: url('<%= primaryPath %><%= zone.primaryItems[0].name %>.jpg');">
             </div>
-            <!-- Remove captions at request of client. Keep the structure around in case we want to add them back -->
-            <!--
-            <div class="card-content slider">
-                <%- zone.primaryItems[0].caption %>
-                <strong><%- zone.primaryItems[0].credit %></strong>
-            </div>
-            -->
             <div class="instructions text-center instructions-first">
                 <p>Align the photo on your device with the environment around you.</p>
                 <button class="nextslide btn enterarea-button btn-primary btn-lg btn-large enter ">Okay, it's aligned!</button>
@@ -102,26 +94,20 @@
             <% } else { %>
                 <div class="card-visual" style="background-image: url('<%= primaryPath %><%= zone.primaryItems[1].name %>.jpg');">
                 </div>
-                <!-- Remove captions at request of client. Keep the structure around in case we want to add them back -->
-                <!--
                 <div class="card-content slider">
                     <%- zone.primaryItems[1].caption %>
                     <strong><%- zone.primaryItems[1].credit %></strong>
                 </div>
-                -->
             <% } %>
         </div>
         <% _.each(zone.secondaryItems, function(item) { %>
             <div class="card next">
                 <div class="card-visual" style="background-image: url('<%= secondaryPath %><%= item.name %>.jpg');"></div>
                 <div class="card-icon"></div>
-                <!-- Remove captions at request of client. Keep the structure around in case we want to add them back -->
-                <!--
                 <div class="card-content slider">
                     <%- item.caption %>
                     <strong><%- item.credit %></strong>
                 </div>
-                -->
             </div>
         <% }); %>
         <% if (zone.historicContext) { %>


### PR DESCRIPTION
This PR re-enables showing photo captions and attributions. The functionality to show them had been previously commented-out. I also adjusted the position of the caption/attribution labels: they now show 60px above the bottom of the screen, just above the "Swipe left to continue" label. I fixed how the labels would show and hide on taps accordingly. 

I tested it on the Nexus 7 simulator in Chrome, and the result looks like this:

![screen shot 2016-03-30 at 4 11 15 pm](https://cloud.githubusercontent.com/assets/4165523/14156051/72038fd0-f692-11e5-9a34-2d762d5f002e.png)

**Testing**
To test this in a dev env:

- get this branch
- follow the instructions in ["Developer Setup" here](https://github.com/azavea/pwd-waterworks-revealed/blob/master/README.md]) to get a local env setup.
- run `npm install phonegap -g` (probably as `sudo`)
- run `grunt app` to build the app
- run `phonegap serve` to run it on a server
- visit `localhost:3000` (or the address PhoneGap specifies) in Chrome
- turn on Chrome's Mobile Device simulator mode
- tap til you reach a map screen with a hamburger menu in the top left corner
- tap the hamburger icon, then "Settings", then turn "Enable Mock Locations" ON
- tap the hamburger, then tap "Explore the Map", then tap to move your location northwest toward the Waterworks
- tap inside one of the pink rings, then tap enter to go through the slideshow

When you reach the image screens with captions, verify that:
- the caption/attribution label appears above the "Swipe left to continue" label
- tapping the screen anywhere causes the caption label to show and hide by sliding off the bottom of the screen and by sliding up again from the bottom of the screen
- when showing the caption label again after hiding it, the label snaps back to its proper position above the "Swipe left" label
- if the caption label's shown on one screen, it will appear as shown on next screen on swiping left
- if the label's hidden on one screen, it will be hidden on the next screen -- and tapping anywhere will cause it to show again

Connects #176